### PR TITLE
Add Starlette integration

### DIFF
--- a/examples/starlette_app.py
+++ b/examples/starlette_app.py
@@ -1,0 +1,67 @@
+import logging
+from abc import abstractmethod
+from typing import Annotated, Protocol
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+from dishka import Provider, Scope, provide
+from dishka.integrations.starlette import Depends, inject, DishkaApp
+
+
+# app core
+class DbGateway(Protocol):
+    @abstractmethod
+    def get(self) -> str:
+        raise NotImplementedError
+
+
+class FakeDbGateway(DbGateway):
+    def get(self) -> str:
+        return "Hello from Starlette"
+
+
+class Interactor:
+    def __init__(self, db: DbGateway):
+        self.db = db
+
+    def __call__(self) -> str:
+        return self.db.get()
+
+
+# app dependency logic
+class AdaptersProvider(Provider):
+    @provide(scope=Scope.REQUEST)
+    def get_db(self) -> DbGateway:
+        return FakeDbGateway()
+
+
+class InteractorProvider(Provider):
+    i1 = provide(Interactor, scope=Scope.REQUEST)
+
+
+# presentation layer
+@inject
+async def index(request: Request, *, interactor: Annotated[Interactor, Depends()]) -> PlainTextResponse:
+    result = interactor()
+    return PlainTextResponse(result)
+
+
+def create_app():
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s  %(process)-7s %(module)-20s %(message)s",
+    )
+
+    app = Starlette(routes=[Route("/", endpoint=index, methods=["GET"])])
+    return DishkaApp(
+        providers=[AdaptersProvider(), InteractorProvider()],
+        app=app,
+    )
+
+
+if __name__ == "__main__":
+    uvicorn.run(create_app(), host="0.0.0.0", port=8000, lifespan="on")

--- a/requirements/starlette-0270.txt
+++ b/requirements/starlette-0270.txt
@@ -1,0 +1,2 @@
+-r asgi.txt
+starlette==0.27.0

--- a/requirements/starlette-0371.txt
+++ b/requirements/starlette-0371.txt
@@ -1,0 +1,2 @@
+-r asgi.txt
+starlette==0.37.1

--- a/requirements/starlette-0371.txt
+++ b/requirements/starlette-0371.txt
@@ -1,2 +1,0 @@
--r asgi.txt
-starlette==0.37.1

--- a/requirements/starlette-latest.txt
+++ b/requirements/starlette-latest.txt
@@ -1,0 +1,2 @@
+-r asgi.txt
+starlette

--- a/src/dishka/integrations/starlette.py
+++ b/src/dishka/integrations/starlette.py
@@ -1,0 +1,47 @@
+__all__ = ["Depends", "inject", "DishkaApp"]
+
+from starlette.requests import Request
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from dishka import AsyncContainer
+from ..async_container import AsyncContextWrapper
+from .asgi import BaseDishkaApp
+from .base import Depends, wrap_injection
+
+
+def inject(func):
+    return wrap_injection(
+        func=func,
+        remove_depends=True,
+        container_getter=lambda r, _: r[0].scope["state"]["dishka_container"],
+        additional_params=[],
+        is_async=True,
+    )
+
+
+class ContainerMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(
+            self, scope: Scope, receive: Receive, send: Send,
+    ) -> None:
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        request = Request(scope)
+        async with request.app.state.dishka_container(
+                {Request: request},
+        ) as request_container:
+            request.state.dishka_container = request_container
+            await self.app(scope, receive, send)
+
+
+class DishkaApp(BaseDishkaApp):
+    def _init_request_middleware(
+            self, app, container_wrapper: AsyncContextWrapper,
+    ):
+        app.add_middleware(ContainerMiddleware)
+
+    def _app_startup(self, app, container: AsyncContainer):
+        app.state.dishka_container = container

--- a/tests/integrations/starlette/__init__.py
+++ b/tests/integrations/starlette/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("starlette")

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -1,0 +1,83 @@
+from contextlib import asynccontextmanager
+from typing import Annotated
+from unittest.mock import Mock
+
+import pytest
+from asgi_lifespan import LifespanManager
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from dishka.integrations.starlette import (
+    Depends,
+    DishkaApp,
+    inject,
+)
+from ..common import (
+    APP_DEP_VALUE,
+    REQUEST_DEP_VALUE,
+    AppDep,
+    AppProvider,
+    RequestDep,
+)
+
+
+@asynccontextmanager
+async def dishka_app(view, provider) -> TestClient:
+    app = Starlette(routes=[Route("/", inject(view), methods=["GET"])])
+    app = DishkaApp(
+        providers=[provider],
+        app=app,
+    )
+    async with LifespanManager(app):
+        yield TestClient(app)
+
+
+async def get_with_app(
+        _: Request,
+        a: Annotated[AppDep, Depends()],
+        mock: Annotated[Mock, Depends()],
+) -> PlainTextResponse:
+    mock(a)
+    return PlainTextResponse("passed")
+
+
+@pytest.mark.asyncio
+async def test_app_dependency(app_provider: AppProvider):
+    async with dishka_app(get_with_app, app_provider) as client:
+        client.get("/")
+        app_provider.mock.assert_called_with(APP_DEP_VALUE)
+        app_provider.app_released.assert_not_called()
+    app_provider.app_released.assert_called()
+
+
+async def get_with_request(
+        _: Request,
+        a: Annotated[RequestDep, Depends()],
+        mock: Annotated[Mock, Depends()],
+) -> PlainTextResponse:
+    mock(a)
+    return PlainTextResponse("passed")
+
+
+@pytest.mark.asyncio
+async def test_request_dependency(app_provider: AppProvider):
+    async with dishka_app(get_with_request, app_provider) as client:
+        client.get("/")
+        app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
+        app_provider.request_released.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_request_dependency2(app_provider: AppProvider):
+    async with dishka_app(get_with_request, app_provider) as client:
+        client.get("/")
+        app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
+        app_provider.mock.reset_mock()
+        app_provider.request_released.assert_called_once()
+        app_provider.request_released.reset_mock()
+        client.get("/")
+        app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
+        app_provider.request_released.assert_called_once()

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ env_list =
     litestar-230,
     aiogram-330,
     telebot-415,
+    starlette-0371,
 
 [pytest]
 addopts = --cov=dishka --cov-append --cov-report term-missing -v
@@ -26,6 +27,8 @@ deps =
     flask-302: -r requirements/flask-302.txt
     litestar-latest: -r requirements/litestar-latest.txt
     litestar-230: -r requirements/litestar-230.txt
+    starlette-latest: -r requirements/srarlette-latest.txt
+    starlette-0371: -r requirements/starlette-0371.txt
 
 commands =
     fastapi: pytest tests/integrations/fastapi
@@ -33,6 +36,7 @@ commands =
     telebot: pytest tests/integrations/telebot
     flask: pytest tests/integrations/flask
     litestar: pytest tests/integrations/litestar
+    starlette: pytest tests/integrations/starlette
 
 package = editable
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ env_list =
     litestar-230,
     aiogram-330,
     telebot-415,
-    starlette-0371,
+    starlette-0270,
 
 [pytest]
 addopts = --cov=dishka --cov-append --cov-report term-missing -v
@@ -28,7 +28,7 @@ deps =
     litestar-latest: -r requirements/litestar-latest.txt
     litestar-230: -r requirements/litestar-230.txt
     starlette-latest: -r requirements/srarlette-latest.txt
-    starlette-0371: -r requirements/starlette-0371.txt
+    starlette-0270: -r requirements/starlette-0270.txt
 
 commands =
     fastapi: pytest tests/integrations/fastapi


### PR DESCRIPTION
`Dishka` integration with `Starlette` has been added.
**Important** feature:  `Starlette` is always accepted by `Request` as the first argument.

Checklist:
- [x] Create an example
- [x] Add tests
- [x] Pass `ruff` checks
- [x] Pass tests through `tox`

