### PR TITLE
chore: add codespell to check typos

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,13 +1,11 @@
 line-length = 79
-target-version="py310"
+target-version = "py310"
 src = ["src"]
 
 include = ["src/**.py", "tests/**.py"]
 exclude = ["src/dishka/_adaptix/**"]
 
-lint.select = [
-"ALL"
-]
+lint.select = ["ALL"]
 lint.ignore = [
    "ARG",
    "ANN",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## Dishka (from russian "cute DI")
 
 [![PyPI version](https://badge.fury.io/py/dishka.svg)](https://pypi.python.org/pypi/dishka)
+[![Supported versions](https://img.shields.io/pypi/pyversions/dishka.svg)](https://pypi.python.org/pypi/dishka)
 [![downloads](https://img.shields.io/pypi/dm/dishka.svg)](https://pypistats.org/packages/dishka)
 [![license](https://img.shields.io/github/license/reagento/dishka)](https://github.com/reagento/dishka/blob/master/LICENSE)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/reagento/dishka/setup.yml)](https://github.com/reagento/dishka/actions)
@@ -15,14 +16,15 @@ Cute DI framework with scopes and agreeable API.
 
 This library is targeting to provide only an IoC-container but make it really useful. If you are tired manually passing objects to create others objects which are only used to create more object - we have a solution. Not all project require an IoC-container, but check what we have.
 
-Unlike other instruments we are not trying to solve tasks not related to dependency injection. We want to keep DI in place, not soiling you code with global variables and additional specifiers in all places. 
+Unlike other instruments we are not trying to solve tasks not related to dependency injection. We want to keep DI in place, not soiling you code with global variables and additional specifiers in all places.
 
 Main ideas:
+
 * **Scopes**. Any object can have lifespan of the whole app, single request or even more fractionally. Many frameworks do not have scopes or have only 2 of them. Here you can have as many scopes as you need.
 * **Finalization**. Some dependencies like database connections must be not only created, but carefully released. Many framework lack this essential feature
 * **Modular providers**. Instead of creating lots of separate functions or contrariwise a big single class, you can split your factories into several classes, which makes them simpler reusable.
 * **Clean dependencies**. You do not need to add custom markers to the code of dependencies so to allow library to see them. All customization is done within providers code and only borders of scopes have to deal with library API.
-* **Simple API**. You need minimum of objects to start using library. You can easily integrate it with your task framework, examples provided. 
+* **Simple API**. You need minimum of objects to start using library. You can easily integrate it with your task framework, examples provided.
 * **Speed**. It is fast enough so you not to worry about. It is even faster than many of the analogs.
 
 See more in [technical requirements](https://dishka.readthedocs.io/en/latest/requirements/technical.html)
@@ -84,6 +86,7 @@ container = make_container(provider)  # it has Scope.APP
 a = container.get(A)  # `A` has Scope.APP, so it is accessible here
 
 ```
+
 5. You can enter and exit `REQUEST` scope multiple times after that:
 
 ```python
@@ -138,26 +141,26 @@ You can provide your own Scopes class if you are not satisfied with standard flo
 
 **Container** is what you use to get your dependency. You just call `.get(SomeType)` and it finds a way to get you an instance of that type. It does not create things itself, but manages their lifecycle and caches. It delegates objects creation to providers which are passed during creation.
 
-
-**Provider** is a collection of functions which really provide some objects. 
+**Provider** is a collection of functions which really provide some objects.
 Provider itself is a class with some attributes and methods. Each of them is either result of `provide`, `alias` or `decorate`. They can be used as provider methods, functions to assign attributes or method decorators.
 
 `@provide` can be used as a decorator for some method. This method will be called when corresponding dependency has to be created. Name of the method is not important: just check that it is different form other `Provider` attributes. Type hints do matter: they show what this method creates and what does it require. All method parameters are treated as other dependencies and created using container.
 
 If `provide` is used with some class then that class itself is treated as a factory (`__init__` is analyzed for parameters). But do not forget to assing that call to some attribute otherwise it will be ignored.
 
-
-
 ### Tips
 
 * Add method and mark it with `@provide` decorator. It can be sync or async method returning some value.
+
     ```python
     class MyProvider(Provider):
         @provide(scope=Scope.REQUEST)
         def get_a(self) -> A:
             return A()
     ```
+
 * Want some finalization when exiting the scope? Make that method generator:
+
     ```python
     class MyProvider(Provider):
         @provide(scope=Scope.REQUEST)
@@ -166,22 +169,30 @@ If `provide` is used with some class then that class itself is treated as a fact
             yield a
             a.close()
     ```
-* Do not have any specific logic and just want to create class using its `__init__`? then add a provider attribute using `provide` as function passing that class. 
-    ```python 
+
+* Do not have any specific logic and just want to create class using its `__init__`? then add a provider attribute using `provide` as function passing that class.
+
+    ```python
     class MyProvider(Provider):
         a = provide(A, scope=Scope.REQUEST)
     ```
+
 * Want to create a child class instance when parent is requested? add a `source` attribute to `provide` function with a parent class while passing child as a first parameter
-    ```python 
+
+    ```python
     class MyProvider(Provider):
         a = provide(source=AChild, scope=Scope.REQUEST, provides=A)
     ```
+
 * Having multiple interfaces which can be created as a same class with defined provider? Use alias:
+
     ```python
     class MyProvider(Provider):
         p = alias(source=A, provides=AProtocol)
     ```
+
     it works the same way as
+
     ```python
     class MyProvider(Provider):
         @provide(scope=<Scope of A>)
@@ -190,15 +201,18 @@ If `provide` is used with some class then that class itself is treated as a fact
     ```
 
 * Want to apply decorator pattern and do not want to alter existing provide method? Use `decorate`. It will construct object using earlie defined provider and then pass it to your decorator before returning from the container.
+
   ```python
     class MyProvider(Provider):
         @decorate
         def decorate_a(self, a: A) -> A:
             return ADecorator(a)
    ```
+
   Decorator function can also have additional parameters.
 
 * Want to go `async`? Make provide methods asynchronous. Create async container. Use `async with` and await `get` calls:
+
 ```python
 class MyProvider(Provider):
    @provide(scope=Scope.APP)
@@ -210,6 +224,7 @@ a = await container.get(A)
 ```
 
 * Having some data connected with scope which you want to use when solving dependencies? Set it when entering scope. These classes can be used as parameters of your `provide` methods
+
 ```python
 container = make_async_container(MyProvider(), context={App: app})
 with container(context={RequestClass: request_instance}) as request_container:
@@ -217,11 +232,13 @@ with container(context={RequestClass: request_instance}) as request_container:
 ```
 
 * Having to many dependencies? Or maybe want to replace only part of them in tests keeping others? Create multiple `Provider` classes
+
 ```python
 container = make_container(MyProvider(), OtherProvider())
 ```
 
 * Tired of providing `scope==` for each depedency? Set it inside your `Provider` class and all dependencies with no scope will use it.
+
 ```python
 
 class MyProvider(Provider):

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -10,7 +10,7 @@ Dependency
 ==================
 
 **Dependency** is what you need for some part of your code to work.
-If you *database gateway* needs *database connection* to execute SQL queries, then the connection is a dependency for a gateway. If your business logic class requires *database gateway* or some *api client* then *api client* and *database gateway* are dependencies for a business logic. Here the ``Client`` is a dependency, while ``Service`` is a dependant.
+If you *database gateway* needs *database connection* to execute SQL queries, then the connection is a dependency for a gateway. If your business logic class requires *database gateway* or some *api client* then *api client* and *database gateway* are dependencies for a business logic. Here the ``Client`` is a dependency, while ``Service`` is a dependent.
 
 .. code-block:: python
 

--- a/docs/container/index.rst
+++ b/docs/container/index.rst
@@ -60,7 +60,7 @@ And async:
     a = await container.get(A)
     a = await container.get(A)  # same instance
 
-Whe you exit the scope, dependency cache is cleared. Finalization of dependencies is done if you used generator factories.
+When you exit the scope, dependency cache is cleared. Finalization of dependencies is done if you used generator factories.
 
 APP-level container is not a context manager, so call ``.close()`` on your app termination
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,8 +24,7 @@ Getting started
 
 .. code-block::
 
-    pip install -r requirements_dev.txt
-    pip install -e .
+    pip install -e . -r requirements_dev.txt
 
 Running linters
 =====================
@@ -35,6 +34,12 @@ Currently we use ``ruff`` to check code. To run it do
 .. code-block::
 
     ruff check
+
+Or run ``tox`` script
+
+.. code-block::
+
+    tox run -e lint
 
 We do not use ruff formatter for all code, so ensure that you formatted only your part of code proposing new changes.
 We have a lot of checks enabled and some of them can be false positive. Double check your code before suppressing any linter warning.

--- a/docs/provider/provide.rst
+++ b/docs/provider/provide.rst
@@ -59,7 +59,7 @@ By default the result is cached within scope. You can disable it providing ``cac
     container = make_async_container(MyProvider())
     a = await container.get(A)
 
-* Tired of providing `scope==` for each depedency? Set it inside your `Provider` class and all factories with no scope will use it.
+* Tired of providing `scope==` for each dependency? Set it inside your `Provider` class and all factories with no scope will use it.
 
 .. code-block:: python
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,7 +16,7 @@ Quickstart
 
     provider = Provider()
 
-3. Register functions which provide dependencies. Do not forget to place correct typehints for parameters and result. We use ``scope=Scope.APP`` for dependencies which ar created only once in applicaiton lifetime, and ``scope=Scope.REQUEST`` for those which should be recreated for each processing request/event/etc.
+3. Register functions which provide dependencies. Do not forget to place correct typehints for parameters and result. We use ``scope=Scope.APP`` for dependencies which ar created only once in application lifetime, and ``scope=Scope.REQUEST`` for those which should be recreated for each processing request/event/etc.
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
@@ -31,7 +33,7 @@ dependencies = [
 ]
 
 [project.urls]
+"Source" = "https://github.com/reagento/dishka"
 "Homepage" = "https://github.com/reagento/dishka"
+"Documentation" = "https://dishka.readthedocs.io/en/stable/"
 "Bug Tracker" = "https://github.com/reagento/dishka/issues"
-
-

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
 ruff==0.2.*
 tox==4.12.*
+codespell==2.2.*

--- a/src/dishka/__init__.py
+++ b/src/dishka/__init__.py
@@ -1,9 +1,14 @@
 __all__ = [
-    "make_async_container", "AsyncContainer",
-    "make_container", "Container",
+    "make_async_container",
+    "AsyncContainer",
+    "make_container",
+    "Container",
     "Provider",
-    "alias", "decorate", "provide",
-    "BaseScope", "Scope",
+    "alias",
+    "decorate",
+    "provide",
+    "BaseScope",
+    "Scope",
 ]
 
 from .async_container import AsyncContainer, make_async_container

--- a/src/dishka/_adaptix/type_tools/generic_resolver.py
+++ b/src/dishka/_adaptix/type_tools/generic_resolver.py
@@ -16,7 +16,7 @@ K = TypeVar('K', bound=Hashable)
 @dataclass
 class MembersStorage(Generic[K, M]):
     members: Mapping[K, TypeHint]
-    overriden: Collection[K]
+    overridden: Collection[K]
     meta: M
 
 
@@ -95,7 +95,7 @@ class GenericResolver(Generic[K, M]):
                     bases_members[key]
                     if (
                         key in bases_members
-                        and key not in members_storage.overriden
+                        and key not in members_storage.overridden
                         and (is_generic(value) or isinstance(value, TypeVar))
                     )
                     else value

--- a/src/dishka/async_container.py
+++ b/src/dishka/async_container.py
@@ -25,17 +25,21 @@ class Exit:
 
 class AsyncContainer:
     __slots__ = (
-        "registry", "child_registries", "context", "parent_container",
-        "lock", "_exits",
+        "registry",
+        "child_registries",
+        "context",
+        "parent_container",
+        "lock",
+        "_exits",
     )
 
     def __init__(
-            self,
-            registry: Registry,
-            *child_registries: Registry,
-            parent_container: Optional["AsyncContainer"] = None,
-            context: dict | None = None,
-            lock_factory: Callable[[], Lock] | None = None,
+        self,
+        registry: Registry,
+        *child_registries: Registry,
+        parent_container: Optional["AsyncContainer"] = None,
+        context: dict | None = None,
+        lock_factory: Callable[[], Lock] | None = None,
     ):
         self.registry = registry
         self.child_registries = child_registries
@@ -50,9 +54,9 @@ class AsyncContainer:
         self._exits: list[Exit] = []
 
     def _create_child(
-            self,
-            context: dict | None,
-            lock_factory: Callable[[], Lock] | None,
+        self,
+        context: dict | None,
+        lock_factory: Callable[[], Lock] | None,
     ) -> "AsyncContainer":
         return AsyncContainer(
             *self.child_registries,
@@ -62,9 +66,9 @@ class AsyncContainer:
         )
 
     def __call__(
-            self,
-            context: dict | None = None,
-            lock_factory: Callable[[], Lock] | None = None,
+        self,
+        context: dict | None = None,
+        lock_factory: Callable[[], Lock] | None = None,
     ) -> "AsyncContextWrapper":
         """
         Prepare container for entering the inner scope.
@@ -77,7 +81,9 @@ class AsyncContainer:
         return AsyncContextWrapper(self._create_child(context, lock_factory))
 
     async def _get_from_self(
-            self, factory: Factory, dependency_type: Any,
+        self,
+        factory: Factory,
+        dependency_type: Any,
     ) -> T:
         try:
             sub_dependencies = [
@@ -157,10 +163,10 @@ class AsyncContextWrapper:
 
 
 def make_async_container(
-        *providers: Provider,
-        scopes: type[BaseScope] = Scope,
-        context: dict | None = None,
-        lock_factory: Callable[[], Lock] | None = Lock,
+    *providers: Provider,
+    scopes: type[BaseScope] = Scope,
+    context: dict | None = None,
+    lock_factory: Callable[[], Lock] | None = Lock,
 ) -> AsyncContainer:
     registries = make_registries(*providers, scopes=scopes)
     return AsyncContainer(

--- a/src/dishka/container.py
+++ b/src/dishka/container.py
@@ -25,17 +25,21 @@ class Exit:
 
 class Container:
     __slots__ = (
-        "registry", "child_registries", "context", "parent_container",
-        "lock", "_exits",
+        "registry",
+        "child_registries",
+        "context",
+        "parent_container",
+        "lock",
+        "_exits",
     )
 
     def __init__(
-            self,
-            registry: Registry,
-            *child_registries: Registry,
-            parent_container: Optional["Container"] = None,
-            context: dict | None = None,
-            lock_factory: Callable[[], Lock] | None = None,
+        self,
+        registry: Registry,
+        *child_registries: Registry,
+        parent_container: Optional["Container"] = None,
+        context: dict | None = None,
+        lock_factory: Callable[[], Lock] | None = None,
     ):
         self.registry = registry
         self.child_registries = child_registries
@@ -50,9 +54,9 @@ class Container:
         self._exits: list[Exit] = []
 
     def _create_child(
-            self,
-            context: dict | None,
-            lock_factory: Callable[[], Lock] | None,
+        self,
+        context: dict | None,
+        lock_factory: Callable[[], Lock] | None,
     ) -> "Container":
         return Container(
             *self.child_registries,
@@ -62,9 +66,9 @@ class Container:
         )
 
     def __call__(
-            self,
-            context: dict | None = None,
-            lock_factory: Callable[[], Lock] | None = None,
+        self,
+        context: dict | None = None,
+        lock_factory: Callable[[], Lock] | None = None,
     ) -> "ContextWrapper":
         """
         Prepare container for entering the inner scope.
@@ -77,7 +81,9 @@ class Container:
         return ContextWrapper(self._create_child(context, lock_factory))
 
     def _get_from_self(
-            self, factory: Factory, dependency_type: Any,
+        self,
+        factory: Factory,
+        dependency_type: Any,
     ) -> T:
         try:
             sub_dependencies = [
@@ -159,10 +165,10 @@ class ContextWrapper:
 
 
 def make_container(
-        *providers: Provider,
-        scopes: type[BaseScope] = Scope,
-        context: dict | None = None,
-        lock_factory: Callable[[], Lock] | None = None,
+    *providers: Provider,
+    scopes: type[BaseScope] = Scope,
+    context: dict | None = None,
+    lock_factory: Callable[[], Lock] | None = None,
 ) -> Container:
     registries = make_registries(*providers, scopes=scopes)
     return Container(*registries, context=context, lock_factory=lock_factory)

--- a/src/dishka/dependency_source.py
+++ b/src/dishka/dependency_source.py
@@ -56,20 +56,25 @@ def _identity(x: Any) -> Any:
 
 class Factory:
     __slots__ = (
-        "dependencies", "source", "provides", "scope", "type",
-        "is_to_bind", "cache",
+        "dependencies",
+        "source",
+        "provides",
+        "scope",
+        "type",
+        "is_to_bind",
+        "cache",
     )
 
     def __init__(
-            self,
-            *,
-            dependencies: Sequence[Any],
-            source: Any,
-            provides: type,
-            scope: BaseScope | None,
-            type_: FactoryType,
-            is_to_bind: bool,
-            cache: bool,
+        self,
+        *,
+        dependencies: Sequence[Any],
+        source: Any,
+        provides: type,
+        scope: BaseScope | None,
+        type_: FactoryType,
+        is_to_bind: bool,
+        cache: bool,
     ):
         self.dependencies = dependencies
         self.source = source
@@ -103,14 +108,14 @@ class Factory:
 def _get_init_members(tp) -> MembersStorage[str, None]:
     type_hints = get_all_type_hints(tp.__init__)
     if "__init__" in tp.__dict__:
-        overriden = frozenset(type_hints)
+        overridden = frozenset(type_hints)
     else:
-        overriden = {}
+        overridden = {}
 
     return MembersStorage(
         meta=None,
         members=type_hints,
-        overriden=overriden,
+        overridden=overridden,
     )
 
 
@@ -164,11 +169,11 @@ def _clean_result_hint(factory_type: FactoryType, possible_dependency: Any):
 
 
 def _make_factory_by_class(
-        *,
-        provides: Any,
-        scope: BaseScope | None,
-        source: Callable,
-        cache: bool,
+    *,
+    provides: Any,
+    scope: BaseScope | None,
+    source: Callable,
+    cache: bool,
 ):
     # we need to fix concrete generics and normal classes as well
     # as classes can be children of concrete generics
@@ -192,11 +197,11 @@ def _make_factory_by_class(
 
 
 def _make_factory_by_method(
-        *,
-        provides: Any,
-        scope: BaseScope | None,
-        source: Callable | classmethod,
-        cache: bool,
+    *,
+    provides: Any,
+    scope: BaseScope | None,
+    source: Callable | classmethod,
+    cache: bool,
 ):
     if isinstance(source, classmethod):
         params = signature(source.__wrapped__).parameters
@@ -232,11 +237,11 @@ def _make_factory_by_method(
 
 
 def _make_factory_by_static_method(
-        *,
-        provides: Any,
-        scope: BaseScope | None,
-        source: staticmethod,
-        cache: bool,
+    *,
+    provides: Any,
+    scope: BaseScope | None,
+    source: staticmethod,
+    cache: bool,
 ):
     factory_type = _guess_factory_type(source.__wrapped__)
     hints = get_type_hints(source, include_extras=True)
@@ -257,11 +262,11 @@ def _make_factory_by_static_method(
 
 
 def _make_factory_by_other_callable(
-        *,
-        provides: Any,
-        scope: BaseScope | None,
-        source: Callable,
-        cache: bool,
+    *,
+    provides: Any,
+    scope: BaseScope | None,
+    source: Callable,
+    cache: bool,
 ):
     if _is_bound_method(source):
         to_check = source.__func__
@@ -292,30 +297,42 @@ def _make_factory_by_other_callable(
 
 
 def make_factory(
-        *,
-        provides: Any,
-        scope: BaseScope | None,
-        source: Callable,
-        cache: bool,
+    *,
+    provides: Any,
+    scope: BaseScope | None,
+    source: Callable,
+    cache: bool,
 ) -> Factory:
     if is_bare_generic(source):
         source = source[get_type_vars(source)]
 
     if isclass(source) or get_origin(source):
         return _make_factory_by_class(
-            provides=provides, scope=scope, source=source, cache=cache,
+            provides=provides,
+            scope=scope,
+            source=source,
+            cache=cache,
         )
     elif isfunction(source) or isinstance(source, classmethod):
         return _make_factory_by_method(
-            provides=provides, scope=scope, source=source, cache=cache,
+            provides=provides,
+            scope=scope,
+            source=source,
+            cache=cache,
         )
     elif isinstance(source, staticmethod):
         return _make_factory_by_static_method(
-            provides=provides, scope=scope, source=source, cache=cache,
+            provides=provides,
+            scope=scope,
+            source=source,
+            cache=cache,
         )
     elif callable(source):
         return _make_factory_by_other_callable(
-            provides=provides, scope=scope, source=source, cache=cache,
+            provides=provides,
+            scope=scope,
+            source=source,
+            cache=cache,
         )
     else:
         raise TypeError(f"Cannot use {type(source)} as a factory")
@@ -323,31 +340,31 @@ def make_factory(
 
 @overload
 def provide(
-        *,
-        scope: BaseScope = None,
-        provides: Any = None,
-        cache: bool = True,
+    *,
+    scope: BaseScope = None,
+    provides: Any = None,
+    cache: bool = True,
 ) -> Callable[[Callable], Factory]:
     ...
 
 
 @overload
 def provide(
-        source: Callable | classmethod | staticmethod | type | None,
-        *,
-        scope: BaseScope | None = None,
-        provides: Any = None,
-        cache: bool = True,
+    source: Callable | classmethod | staticmethod | type | None,
+    *,
+    scope: BaseScope | None = None,
+    provides: Any = None,
+    cache: bool = True,
 ) -> Factory:
     ...
 
 
 def provide(
-        source: Callable | classmethod | staticmethod | type | None = None,
-        *,
-        scope: BaseScope | None = None,
-        provides: Any = None,
-        cache: bool = True,
+    source: Callable | classmethod | staticmethod | type | None = None,
+    *,
+    scope: BaseScope | None = None,
+    provides: Any = None,
+    cache: bool = True,
 ) -> Factory | Callable[[Callable], Factory]:
     """
     Mark a method or class as providing some dependency.
@@ -371,12 +388,18 @@ def provide(
     """
     if source is not None:
         return make_factory(
-            provides=provides, scope=scope, source=source, cache=cache,
+            provides=provides,
+            scope=scope,
+            source=source,
+            cache=cache,
         )
 
     def scoped(func):
         return make_factory(
-            provides=provides, scope=scope, source=func, cache=cache,
+            provides=provides,
+            scope=scope,
+            source=func,
+            cache=cache,
         )
 
     return scoped
@@ -406,10 +429,10 @@ class Alias:
 
 
 def alias(
-        *,
-        source: type,
-        provides: type,
-        cache: bool = True,
+    *,
+    source: type,
+    provides: type,
+    cache: bool = True,
 ) -> Alias:
     return Alias(
         source=source,
@@ -426,7 +449,11 @@ class Decorator:
         self.provides = factory.provides
 
     def as_factory(
-            self, *, scope: BaseScope, new_dependency: Any, cache: bool,
+        self,
+        *,
+        scope: BaseScope,
+        new_dependency: Any,
+        cache: bool,
     ) -> Factory:
         return Factory(
             scope=scope,
@@ -447,34 +474,44 @@ class Decorator:
 
 @overload
 def decorate(
-        *,
-        provides: Any = None,
+    *,
+    provides: Any = None,
 ) -> Callable[[Callable], Decorator]:
     ...
 
 
 @overload
 def decorate(
-        source: Callable | type,
-        *,
-        provides: Any = None,
+    source: Callable | type,
+    *,
+    provides: Any = None,
 ) -> Decorator:
     ...
 
 
 def decorate(
-        source: Callable | type | None = None,
-        provides: Any = None,
+    source: Callable | type | None = None,
+    provides: Any = None,
 ) -> Decorator | Callable[[Callable], Decorator]:
     if source is not None:
-        return Decorator(make_factory(
-            provides=provides, scope=None, source=source, cache=False,
-        ))
+        return Decorator(
+            make_factory(
+                provides=provides,
+                scope=None,
+                source=source,
+                cache=False,
+            ),
+        )
 
     def scoped(func):
-        return Decorator(make_factory(
-            provides=provides, scope=None, source=func, cache=False,
-        ))
+        return Decorator(
+            make_factory(
+                provides=provides,
+                scope=None,
+                source=func,
+                cache=False,
+            ),
+        )
 
     return scoped
 

--- a/src/dishka/integrations/aiogram.py
+++ b/src/dishka/integrations/aiogram.py
@@ -17,11 +17,13 @@ CONTAINER_NAME = "dishka_container"
 
 
 def inject(func):
-    additional_params = [Parameter(
-        name=CONTAINER_NAME,
-        annotation=Container,
-        kind=Parameter.KEYWORD_ONLY,
-    )]
+    additional_params = [
+        Parameter(
+            name=CONTAINER_NAME,
+            annotation=Container,
+            kind=Parameter.KEYWORD_ONLY,
+        ),
+    ]
 
     return wrap_injection(
         func=func,
@@ -37,7 +39,10 @@ class ContainerMiddleware(BaseMiddleware):
         self.container = container
 
     async def __call__(
-            self, handler, event, data,
+        self,
+        handler,
+        event,
+        data,
     ):
         async with self.container({TelegramObject: event}) as sub_container:
             data[CONTAINER_NAME] = sub_container

--- a/src/dishka/integrations/aiohttp.py
+++ b/src/dishka/integrations/aiohttp.py
@@ -1,5 +1,8 @@
 __all__ = [
-    "Depends", "DISHKA_CONTAINER_KEY", "inject", "setup_dishka",
+    "Depends",
+    "DISHKA_CONTAINER_KEY",
+    "inject",
+    "setup_dishka",
 ]
 
 from collections.abc import Callable
@@ -28,7 +31,8 @@ def inject(func: Callable) -> Callable:
 
 @web.middleware
 async def container_middleware(
-    request: Request, handler: Handler,
+    request: Request,
+    handler: Handler,
 ) -> StreamResponse:
     container = request.app[DISHKA_CONTAINER_KEY]
     async with container(context={Request: request}) as request_container:

--- a/src/dishka/integrations/base.py
+++ b/src/dishka/integrations/base.py
@@ -20,11 +20,11 @@ class Depends:
 
 
 def default_parse_dependency(
-        parameter: Parameter,
-        hint: Any,
-        depends_class: type[Any] = Depends,
+    parameter: Parameter,
+    hint: Any,
+    depends_class: type[Any] = Depends,
 ) -> Any:
-    """ Resolve dependency type or return None if it is not a dependency """
+    """Resolve dependency type or return None if it is not a dependency"""
     if get_origin(hint) is not Annotated:
         return None
     dep = next(
@@ -44,38 +44,38 @@ DependencyParser = Callable[[Parameter, Any], Any]
 
 @overload
 def wrap_injection(
-        *,
-        func: Callable,
-        container_getter: Callable[[tuple, dict], Container],
-        is_async: Literal[False] = False,
-        remove_depends: bool = True,
-        additional_params: Sequence[Parameter] = (),
-        parse_dependency: DependencyParser = default_parse_dependency,
+    *,
+    func: Callable,
+    container_getter: Callable[[tuple, dict], Container],
+    is_async: Literal[False] = False,
+    remove_depends: bool = True,
+    additional_params: Sequence[Parameter] = (),
+    parse_dependency: DependencyParser = default_parse_dependency,
 ) -> Callable:
     ...
 
 
 @overload
 def wrap_injection(
-        *,
-        func: Callable,
-        container_getter: Callable[[tuple, dict], AsyncContainer],
-        is_async: Literal[True],
-        remove_depends: bool = True,
-        additional_params: Sequence[Parameter] = (),
-        parse_dependency: DependencyParser = default_parse_dependency,
+    *,
+    func: Callable,
+    container_getter: Callable[[tuple, dict], AsyncContainer],
+    is_async: Literal[True],
+    remove_depends: bool = True,
+    additional_params: Sequence[Parameter] = (),
+    parse_dependency: DependencyParser = default_parse_dependency,
 ) -> Awaitable:
     ...
 
 
 def wrap_injection(
-        *,
-        func: Callable,
-        container_getter: Callable,
-        is_async: bool = False,
-        remove_depends: bool = True,
-        additional_params: Sequence[Parameter] = (),
-        parse_dependency: DependencyParser = default_parse_dependency,
+    *,
+    func: Callable,
+    container_getter: Callable,
+    is_async: bool = False,
+    remove_depends: bool = True,
+    additional_params: Sequence[Parameter] = (),
+    parse_dependency: DependencyParser = default_parse_dependency,
 ):
     hints = get_type_hints(func, include_extras=True)
     func_signature = signature(func)
@@ -134,10 +134,10 @@ def wrap_injection(
 
 
 def _async_injection_wrapper(
-        container_getter: Callable,
-        additional_params: Sequence[Parameter],
-        dependencies: dict[str, Any],
-        func: Callable,
+    container_getter: Callable,
+    additional_params: Sequence[Parameter],
+    dependencies: dict[str, Any],
+    func: Callable,
 ):
     async def autoinjected_func(*args, **kwargs):
         container = container_getter(args, kwargs)
@@ -153,18 +153,17 @@ def _async_injection_wrapper(
 
 
 def _sync_injection_wrapper(
-        container_getter: Callable,
-        additional_params: Sequence[Parameter],
-        dependencies: dict[str, Any],
-        func: Callable,
+    container_getter: Callable,
+    additional_params: Sequence[Parameter],
+    dependencies: dict[str, Any],
+    func: Callable,
 ):
     def autoinjected_func(*args, **kwargs):
         container = container_getter(args, kwargs)
         for param in additional_params:
             kwargs.pop(param.name)
         solved = {
-            name: container.get(dep)
-            for name, dep in dependencies.items()
+            name: container.get(dep) for name, dep in dependencies.items()
         }
         return func(*args, **kwargs, **solved)
 

--- a/src/dishka/integrations/fastapi.py
+++ b/src/dishka/integrations/fastapi.py
@@ -1,5 +1,7 @@
 __all__ = [
-    "Depends", "inject", "setup_dishka",
+    "Depends",
+    "inject",
+    "setup_dishka",
 ]
 
 from inspect import Parameter
@@ -21,11 +23,13 @@ def inject(func):
         additional_params = []
     else:
         request_param = "____dishka_request"
-        additional_params = [Parameter(
-            name=request_param,
-            annotation=Request,
-            kind=Parameter.KEYWORD_ONLY,
-        )]
+        additional_params = [
+            Parameter(
+                name=request_param,
+                annotation=Request,
+                kind=Parameter.KEYWORD_ONLY,
+            ),
+        ]
 
     return wrap_injection(
         func=func,
@@ -38,7 +42,7 @@ def inject(func):
 
 async def add_request_container_middleware(request: Request, call_next):
     async with request.app.state.dishka_container(
-            {Request: request},
+        {Request: request},
     ) as request_container:
         request.state.dishka_container = request_container
         return await call_next(request)

--- a/src/dishka/integrations/faststream.py
+++ b/src/dishka/integrations/faststream.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any, ParamSpec, TypeVar
 
@@ -18,7 +18,7 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def inject(func: Callable[P, T]) -> Callable[P, T]:
+def inject(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
     return wrap_injection(
         func=func,
         container_getter=lambda *_: context.get_local("dishka"),

--- a/src/dishka/integrations/flask.py
+++ b/src/dishka/integrations/flask.py
@@ -1,5 +1,7 @@
 __all__ = [
-    "inject", "setup_dishka", "Depends",
+    "inject",
+    "setup_dishka",
+    "Depends",
 ]
 
 from flask import Flask, Request, g, request

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -1,5 +1,7 @@
 __all__ = [
-    "Depends", "inject", "setup_dishka",
+    "Depends",
+    "inject",
+    "setup_dishka",
 ]
 
 from inspect import Parameter
@@ -23,11 +25,13 @@ def inject(func):
         additional_params = []
     else:
         request_param = "request"
-        additional_params = [Parameter(
-            name=request_param,
-            annotation=Request | None,
-            kind=Parameter.KEYWORD_ONLY,
-        )]
+        additional_params = [
+            Parameter(
+                name=request_param,
+                annotation=Request | None,
+                kind=Parameter.KEYWORD_ONLY,
+            ),
+        ]
 
     return wrap_injection(
         func=func,
@@ -46,7 +50,7 @@ def make_add_request_container_middleware(app: ASGIApp):
 
         request = Request(scope)
         async with request.app.state.dishka_container(
-                {Request: request},
+            {Request: request},
         ) as request_container:
             request.state.dishka_container = request_container
             await app(scope, receive, send)

--- a/src/dishka/integrations/starlette.py
+++ b/src/dishka/integrations/starlette.py
@@ -23,14 +23,17 @@ class ContainerMiddleware:
         self.app = app
 
     async def __call__(
-            self, scope: Scope, receive: Receive, send: Send,
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
     ) -> None:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
         request = Request(scope)
         async with request.app.state.dishka_container(
-                {Request: request},
+            {Request: request},
         ) as request_container:
             request.state.dishka_container = request_container
             return await self.app(scope, receive, send)

--- a/src/dishka/integrations/telebot.py
+++ b/src/dishka/integrations/telebot.py
@@ -16,11 +16,13 @@ CONTAINER_NAME = "dishka_container"
 
 
 def inject(func):
-    additional_params = [Parameter(
-        name=CONTAINER_NAME,
-        annotation=Container,
-        kind=Parameter.KEYWORD_ONLY,
-    )]
+    additional_params = [
+        Parameter(
+            name=CONTAINER_NAME,
+            annotation=Container,
+            kind=Parameter.KEYWORD_ONLY,
+        ),
+    ]
 
     return wrap_injection(
         func=func,

--- a/src/dishka/provider.py
+++ b/src/dishka/provider.py
@@ -32,6 +32,7 @@ class Provider:
     The only intended usage of providers is to pass them when
     creating a container
     """
+
     scope: BaseScope | None = None
 
     def __init__(self, scope: BaseScope | None = None):
@@ -61,12 +62,12 @@ class Provider:
             processed_types[source.provides] = name
 
     def provide(
-            self,
-            source: Callable | type,
-            *,
-            scope: BaseScope | None = None,
-            provides: Any = None,
-            cache: bool = True,
+        self,
+        source: Callable | type,
+        *,
+        scope: BaseScope | None = None,
+        provides: Any = None,
+        cache: bool = True,
     ) -> Factory:
         if scope is None:
             scope = self.scope
@@ -80,11 +81,11 @@ class Provider:
         return new_factory
 
     def alias(
-            self,
-            *,
-            source: type,
-            provides: type,
-            cache: bool = True,
+        self,
+        *,
+        source: type,
+        provides: type,
+        cache: bool = True,
     ) -> Alias:
         new_alias = alias(
             source=source,
@@ -95,10 +96,10 @@ class Provider:
         return new_alias
 
     def decorate(
-            self,
-            source: Callable | type,
-            *,
-            provides: Any = None,
+        self,
+        source: Callable | type,
+        *,
+        provides: Any = None,
     ) -> Decorator:
         new_decorator = decorate(
             source=source,

--- a/src/dishka/registry.py
+++ b/src/dishka/registry.py
@@ -37,21 +37,28 @@ class Registry:
             return factory
 
     def _specialize_generic(
-            self, factory: Factory, dependency: Any,
+        self,
+        factory: Factory,
+        dependency: Any,
     ) -> Factory:
-        params_replacement = dict(zip(
-            get_args(factory.provides),
-            get_args(dependency), strict=False,
-        ))
+        params_replacement = dict(
+            zip(
+                get_args(factory.provides),
+                get_args(dependency),
+                strict=False,
+            ),
+        )
         new_dependencies = []
         for source_dependency in factory.dependencies:
             if isinstance(source_dependency, TypeVar):
                 source_dependency = params_replacement[source_dependency]
             elif get_origin(source_dependency):
-                source_dependency = source_dependency[tuple(
-                    params_replacement[param]
-                    for param in get_type_vars(source_dependency)
-                )]
+                source_dependency = source_dependency[
+                    tuple(
+                        params_replacement[param]
+                        for param in get_type_vars(source_dependency)
+                    )
+                ]
             new_dependencies.append(source_dependency)
         return Factory(
             source=factory.source,
@@ -65,7 +72,8 @@ class Registry:
 
 
 def make_registries(
-        *providers: Provider, scopes: type[BaseScope],
+    *providers: Provider,
+    scopes: type[BaseScope],
 ) -> list[Registry]:
     dep_scopes: dict[type, BaseScope] = {}
     alias_sources = {}

--- a/tests/integrations/aiogram/test_aiogram.py
+++ b/tests/integrations/aiogram/test_aiogram.py
@@ -32,25 +32,29 @@ async def dishka_app(handler, provider):
 
 
 async def send_message(bot, dp):
-    await dp.feed_update(bot, Update(
-        update_id=1,
-        message=Message(
-            message_id=2,
-            date=datetime.fromtimestamp(1234567890, tz=timezone.utc),
-            chat=Chat(id=1, type="private"),
-            from_user=User(
-                id=1, is_bot=False,
-                first_name="User",
+    await dp.feed_update(
+        bot,
+        Update(
+            update_id=1,
+            message=Message(
+                message_id=2,
+                date=datetime.fromtimestamp(1234567890, tz=timezone.utc),
+                chat=Chat(id=1, type="private"),
+                from_user=User(
+                    id=1,
+                    is_bot=False,
+                    first_name="User",
+                ),
+                text="/start",
             ),
-            text="/start",
         ),
-    ))
+    )
 
 
 async def handle_with_app(
-        _: Message,
-        a: Annotated[AppDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    _: Message,
+    a: Annotated[AppDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 
@@ -66,9 +70,9 @@ async def test_app_dependency(bot, app_provider: AppProvider):
 
 
 async def handle_with_request(
-        _: Message,
-        a: Annotated[RequestDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    _: Message,
+    a: Annotated[RequestDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 

--- a/tests/integrations/aiohttp/test_aiohttp.py
+++ b/tests/integrations/aiohttp/test_aiohttp.py
@@ -41,9 +41,9 @@ async def dishka_app(view, provider) -> TestClient:
 
 
 async def get_with_app(
-        _,
-        a: Annotated[AppDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    _,
+    a: Annotated[AppDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> Response:
     mock(a)
     return Response(text="passed")
@@ -59,13 +59,12 @@ async def test_app_dependency(app_provider: AppProvider):
 
 
 async def get_with_request(
-        _,
-        a: Annotated[RequestDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    _,
+    a: Annotated[RequestDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> Response:
     mock(a)
     return Response(text="passed")
-
 
 
 @pytest.mark.asyncio

--- a/tests/integrations/fastapi/test_fastapi.py
+++ b/tests/integrations/fastapi/test_fastapi.py
@@ -36,8 +36,8 @@ async def dishka_app(view, provider) -> TestClient:
 
 
 async def get_with_app(
-        a: Annotated[AppDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    a: Annotated[AppDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 
@@ -52,8 +52,8 @@ async def test_app_dependency(app_provider: AppProvider):
 
 
 async def get_with_request(
-        a: Annotated[RequestDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    a: Annotated[RequestDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 
@@ -81,14 +81,14 @@ async def test_request_dependency2(app_provider: AppProvider):
 
 @inject
 async def additional(
-        a: Annotated[RequestDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    a: Annotated[RequestDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ):
     mock(a)
 
 
 async def get_with_depends(
-        a: Annotated[None, fastapi.Depends(additional)],
+    a: Annotated[None, fastapi.Depends(additional)],
 ) -> None:
     pass
 

--- a/tests/integrations/faststream/test_faststream.py
+++ b/tests/integrations/faststream/test_faststream.py
@@ -64,7 +64,6 @@ async def get_with_request(
     return "passed"
 
 
-
 @pytest.mark.asyncio
 async def test_request_dependency(app_provider: AppProvider):
     async with dishka_app(get_with_request, app_provider) as client:

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -26,8 +26,8 @@ def dishka_app(view, provider):
 
 
 def handle_with_app(
-        a: Annotated[AppDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    a: Annotated[AppDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 
@@ -41,8 +41,8 @@ def test_app_dependency(app_provider: AppProvider):
 
 
 def handle_with_request(
-        a: Annotated[RequestDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    a: Annotated[RequestDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 

--- a/tests/integrations/litestar/test_litestar.py
+++ b/tests/integrations/litestar/test_litestar.py
@@ -35,8 +35,8 @@ async def dishka_app(view, provider) -> TestClient:
 
 
 async def get_with_app(
-        a: Annotated[AppDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    a: Annotated[AppDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 
@@ -51,8 +51,8 @@ async def test_app_dependency(app_provider: AppProvider):
 
 
 async def get_with_request(
-        a: Annotated[RequestDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    a: Annotated[RequestDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 

--- a/tests/integrations/starlette/test_starlette.py
+++ b/tests/integrations/starlette/test_starlette.py
@@ -36,9 +36,9 @@ async def dishka_app(view, provider) -> TestClient:
 
 
 async def get_with_app(
-        _: Request,
-        a: Annotated[AppDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    _: Request,
+    a: Annotated[AppDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> PlainTextResponse:
     mock(a)
     return PlainTextResponse("passed")
@@ -54,9 +54,9 @@ async def test_app_dependency(app_provider: AppProvider):
 
 
 async def get_with_request(
-        _: Request,
-        a: Annotated[RequestDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    _: Request,
+    a: Annotated[RequestDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> PlainTextResponse:
     mock(a)
     return PlainTextResponse("passed")

--- a/tests/integrations/telebot/test_telebot.py
+++ b/tests/integrations/telebot/test_telebot.py
@@ -27,22 +27,24 @@ def dishka_app(handler, provider):
 
 
 def send_message(bot: TeleBot):
-    update = Update.de_json({
-        "update_id": 1,
-        "message": {
-            "chat": {"id": 1, "type": "private"},
-            "message_id": 2,
-            "date": 1234567890,
-            "text": "/start",
+    update = Update.de_json(
+        {
+            "update_id": 1,
+            "message": {
+                "chat": {"id": 1, "type": "private"},
+                "message_id": 2,
+                "date": 1234567890,
+                "text": "/start",
+            },
         },
-    })
+    )
     bot.process_new_updates([update])
 
 
 def handle_with_app(
-        _: Message,
-        a: Annotated[AppDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    _: Message,
+    a: Annotated[AppDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 
@@ -56,9 +58,9 @@ def test_app_dependency(app_provider: AppProvider):
 
 
 def handle_with_request(
-        _: Message,
-        a: Annotated[RequestDep, Depends()],
-        mock: Annotated[Mock, Depends()],
+    _: Message,
+    a: Annotated[RequestDep, Depends()],
+    mock: Annotated[Mock, Depends()],
 ) -> None:
     mock(a)
 

--- a/tests/unit/container/test_exceptions.py
+++ b/tests/unit/container/test_exceptions.py
@@ -57,9 +57,12 @@ class MyProvider(Provider):
         raise MyError
 
 
-@pytest.mark.parametrize("dep_type", [
-    SyncFinalizationError,
-])
+@pytest.mark.parametrize(
+    "dep_type",
+    [
+        SyncFinalizationError,
+    ],
+)
 def test_sync(dep_type):
     finalizer = Mock(return_value=123)
     container = make_container(MyProvider(finalizer))
@@ -69,10 +72,13 @@ def test_sync(dep_type):
     finalizer.assert_called_once()
 
 
-@pytest.mark.parametrize("dep_type", [
-    SyncFinalizationError,
-    AsyncFinalizationError,
-])
+@pytest.mark.parametrize(
+    "dep_type",
+    [
+        SyncFinalizationError,
+        AsyncFinalizationError,
+    ],
+)
 @pytest.mark.asyncio
 async def test_async(dep_type):
     finalizer = Mock(return_value=123)

--- a/tests/unit/container/test_generic.py
+++ b/tests/unit/container/test_generic.py
@@ -29,7 +29,8 @@ class B(A[U], Generic[U]):
 
 
 @pytest.mark.parametrize(
-    "cls", [A, B, ReplaceInit],
+    "cls",
+    [A, B, ReplaceInit],
 )
 def test_concrete_generic(cls):
     class MyProvider(Provider):

--- a/tests/unit/container/test_resolve.py
+++ b/tests/unit/container/test_resolve.py
@@ -104,11 +104,14 @@ class OtherClass:
         return A_VALUE
 
 
-@pytest.mark.parametrize("method", [
-    OtherClass().method,
-    OtherClass().classmethod,
-    OtherClass().staticmethod,
-])
+@pytest.mark.parametrize(
+    "method",
+    [
+        OtherClass().method,
+        OtherClass().classmethod,
+        OtherClass().staticmethod,
+    ],
+)
 def test_external_method(method):
     provider = Provider(scope=Scope.APP)
     provider.provide(method)

--- a/tox.ini
+++ b/tox.ini
@@ -59,3 +59,11 @@ install_commands = python -m pip install -U {opts} {packages}
 [testenv:real_world_example]
 deps = -r examples/real_world/requirements_test.txt
 commands = pytest examples/real_world/tests/
+
+[testenv:lint]
+description = run linters
+skip_install = true
+deps = -r requirements_dev.txt
+commands =
+    ruff check --fix
+    codespell src/dishka docs


### PR DESCRIPTION
* Add `codespell` to check typos
* Add `tox run -e lint` script to run **ruff & codespell**
* Fix finded by codespell typos
* Run `ruff check --fix`
* Update `contributing.rst`
* correct [`integrations/base.py` types](https://github.com/reagento/dishka/pull/78/files#diff-4a83bd93ec1a2199fadb8ce8239d0ef5ad3c5a873849d9dc127d31b64395556c)