### PR TITLE
Docs / fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ class MyProvider(Provider):
     request = from_context(provides=RequestClass)
 
     @provide
-    async def get_a(self, request: RequestClass, app: App) -> A:
+    def get_a(self, request: RequestClass, app: App) -> A:
         ...
 
 container = make_container(MyProvider(), context={App: app})

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See more in [technical requirements](https://dishka.readthedocs.io/en/latest/req
 pip install dishka
 ```
 
-2. Create `Provider` instance. It is only used co setup all factories providing your objects.
+2. Create `Provider` instance. It is only used to setup all factories providing your objects.
 
 ```python
 from dishka import Provider

--- a/docs/advanced/testing/index.rst
+++ b/docs/advanced/testing/index.rst
@@ -24,7 +24,7 @@ And a container:
 
 .. literalinclude:: ./container_before.py
 
-First of all - split your application factory and and container setup.
+First of all - split your application factory and container setup.
 
 .. literalinclude:: ./app_factory.py
 

--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -132,7 +132,7 @@ Context data
 
 As ``REQUEST`` scope is entered automatically you cannot pass context data directly, but integrations do it for you:
 
-This objects are passed to context:
+These objects are passed to context:
 
 * aiohttp - ``aiohttp.web_request.Request``
 * Flask - ``flask.Request``

--- a/docs/provider/from_context.rst
+++ b/docs/provider/from_context.rst
@@ -17,7 +17,7 @@ You can put some data manually when entering scope and rely on it in your provid
         request = from_context(provides=RequestClass)
 
         @provide
-        async def get_a(self, request: RequestClass, app: App) -> A:
+        def get_a(self, request: RequestClass, app: App) -> A:
             ...
 
     container = make_container(MyProvider(), context={App: app})

--- a/docs/provider/index.rst
+++ b/docs/provider/index.rst
@@ -63,7 +63,7 @@ Your class-based provider can have ``__init__`` method and methods access ``self
 
         @provide
         def get_connection(self) -> Iterable[Connection]:
-            conn = connect(self.uri)  #
+            conn = connect(self.uri)  # use passed configuration
             yield conn
             conn.close()
 

--- a/docs/provider/index.rst
+++ b/docs/provider/index.rst
@@ -47,7 +47,7 @@ Or using inheritance:
             yield conn
             conn.close()
 
-        gateway = provider.provide(Gateway)
+        gateway = provide(Gateway)
 
     container = make_container(MyProvider(scope=Scope.APP))
 

--- a/docs/provider/index.rst
+++ b/docs/provider/index.rst
@@ -52,7 +52,7 @@ Or using inheritance:
     container = make_container(MyProvider(scope=Scope.APP))
 
 
-You class-based provider can have ``__init__`` method and methods access ``self`` as usual. It can be useful for passing configuration:
+Your class-based provider can have ``__init__`` method and methods access ``self`` as usual. It can be useful for passing configuration:
 
 .. code-block:: python
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,7 +8,7 @@ Quickstart
     pip install dishka
 
 
-2. Create Provider instance. It is only used co setup all factories providing your objects.
+2. Create Provider instance. It is only used to setup all factories providing your objects.
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixes some docs typos.

---

Also small question:
https://github.com/reagento/dishka/blob/759234c87aa96f8a3c5cd6b5714cca8dc71c9e6a/docs/advanced/context.rst?plain=1#L11
Looks like the second sentence is not full.
Would you like to remove it or finish the initial idea?
