### PR TITLE
Skip not DI-related annotations

### DIFF
--- a/src/dishka/entities/key.py
+++ b/src/dishka/entities/key.py
@@ -32,7 +32,7 @@ def hint_to_dependency_key(hint: Any) -> DependencyKey:
         None,
     )
     if from_component is None:
-        return DependencyKey(hint, None)
+        return DependencyKey(args[0], None)
     return DependencyKey(args[0], from_component.component)
 
 

--- a/src/dishka/entities/key.py
+++ b/src/dishka/entities/key.py
@@ -31,6 +31,8 @@ def hint_to_dependency_key(hint: Any) -> DependencyKey:
         (arg for arg in args if isinstance(arg, FromComponent)),
         None,
     )
+    if from_component is None:
+        return DependencyKey(hint, None)
     return DependencyKey(args[0], from_component.component)
 
 

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -7,14 +7,21 @@ from dishka.entities.key import FromComponent, hint_to_dependency_key
 
 class TestDependencyKey:
     @pytest.mark.parametrize(
-        ("hint", "component"),
+        ("hint", "resolved_type", "component"),
         [
-            (Any, None),
-            (str, None),
-            (Annotated[str, {"foo": "bar"}], None),
-            (Annotated[str, FromComponent("baz")], "baz"),
+            (Any, Any, None),
+            (str, str, None),
+            (Annotated[str, {"foo": "bar"}], str, None),
+            (Annotated[str, FromComponent("baz")], str, "baz"),
+            (Annotated[str, FromComponent("baz")], str, "baz"),
         ],
     )
-    def test_hint_to_dependency_key(self, hint: Any, component: str | None):
+    def test_hint_to_dependency_key(
+        self,
+        hint: Any,
+        resolved_type: Any,
+        component: str | None,
+    ):
         key = hint_to_dependency_key(hint)
+        assert key.type_hint == resolved_type
         assert key.component == component

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -1,0 +1,20 @@
+from typing import Annotated, Any
+
+import pytest
+
+from dishka.entities.key import FromComponent, hint_to_dependency_key
+
+
+class TestDependencyKey:
+    @pytest.mark.parametrize(
+        ("hint", "component"),
+        [
+            (Any, None),
+            (str, None),
+            (Annotated[str, {"foo": "bar"}], None),
+            (Annotated[str, FromComponent("baz")], "baz"),
+        ],
+    )
+    def test_hint_to_dependency_key(self, hint: Any, component: str | None):
+        key = hint_to_dependency_key(hint)
+        assert key.component == component

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -13,7 +13,6 @@ class TestDependencyKey:
             (str, str, None),
             (Annotated[str, {"foo": "bar"}], str, None),
             (Annotated[str, FromComponent("baz")], str, "baz"),
-            (Annotated[str, FromComponent("baz")], str, "baz"),
         ],
     )
     def test_hint_to_dependency_key(


### PR DESCRIPTION
Rare case, but anyway we shouldn't call `None.component` if there's no DI-related annotation found