### PR TITLE
wip: example of the component mismatch of to_component

### DIFF
--- a/tests/unit/container/test_components.py
+++ b/tests/unit/container/test_components.py
@@ -89,6 +89,19 @@ def test_change_component():
     assert container.get(int, component="Y") == 20
 
 
+class ToComponentComponentNameProvider(Provider):
+    scope = Scope.APP
+    @provide
+    def my_component(self) -> str:
+        return self.component
+
+def test_change_component_access():
+    provider = ToComponentComponentNameProvider(component="start")
+    container = make_container(provider, provider.to_component("other"))
+    assert container.get(str, component="start") == "start"
+    assert container.get(str, component="other") == "other"
+
+
 def test_set_component():
     container = make_container(SingleProvider(20, component="Y"))
     assert container.get(int, component="Y") == 20


### PR DESCRIPTION
to_component creates a wrapper that copies reconfigured dependencies, however as it turns out, component stays bound to the methods

theres need for either a fixup or a warning on self bound to_component usage
