### PR TITLE
Litestar websockets support

### DIFF
--- a/docs/integrations/litestar.rst
+++ b/docs/integrations/litestar.rst
@@ -76,4 +76,41 @@ How to use
 Websockets
 **********************
 
-Not supported yet
+.. include:: _websockets.rst
+
+In litestar, your view function is called once per event,
+and there is no way to determine if it is an http or websocket handler.
+Therefore, you should use the special ``inject_websocket`` decorator for websocket handlers.
+Also decorator can be only used to retrieve SESSION-scoped objects.
+To achieve REQUEST-scope you can enter in manually:
+
+.. code-block:: python
+
+    @websocket_listener("/")
+    @inject_websocket
+    async def get_with_request(
+        a: FromDishka[A],  # object with Scope.SESSION
+        container: FromDishka[AsyncContainer],  # container for Scope.SESSION
+        data: dict[str, str]
+    ) -> dict[str, str]:
+        # enter the nested scope, which is Scope.REQUEST
+        async with container() as request_container:
+            b = await request_container.get(B)  # object with Scope.REQUEST
+        return {"key": "value"}
+
+or with class-based handler:
+
+.. code-block:: python
+
+    class Handler(WebsocketListener):
+        path = "/"
+
+        @inject_websocket
+        async def on_receive(
+            a: FromDishka[A],  # object with Scope.SESSION
+            container: FromDishka[AsyncContainer],  # container for Scope.SESSION
+            data: dict[str, str]
+        ) -> dict[str, str]:
+            async with container() as request_container:
+                b = await request_container.get(B)  # object with Scope.REQUEST
+            return {"key": "value"}

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -1,13 +1,14 @@
 __all__ = [
     "FromDishka",
     "inject",
+    "inject_websocket",
     "setup_dishka",
     "LitestarProvider",
 ]
 
 from collections.abc import Callable
 from inspect import Parameter
-from typing import ParamSpec, TypeVar, get_type_hints
+from typing import ParamSpec, TypeVar, get_type_hints, Type
 
 from litestar import Litestar, Request, WebSocket
 from litestar.enums import ScopeType
@@ -20,34 +21,41 @@ from dishka.integrations.base import wrap_injection
 P = ParamSpec("P")
 T = TypeVar("T")
 
-def inject(func: Callable[P, T] | None = None, websocket: bool = False):
-    def wrapper(func: Callable[P, T]) -> Callable[P, T]:
-        hints = get_type_hints(func)
+def inject(func: Callable[P, T]):
+    return _inject_wrapper(func, "request", Request)
 
-        request_param_name = "request" if not websocket else "socket"
-        request_param = next(
-            (name for name in hints if name == request_param_name),
-            None,
-        )
 
-        if request_param:
-            additional_params = []
-        else:
-            request_param = request_param_name
-            request_annotation = Request | None if not websocket else WebSocket | None
-            additional_params = [Parameter(
-                name=request_param,
-                annotation=request_annotation,
-                kind=Parameter.KEYWORD_ONLY,
-            )]
+def inject_websocket(func: Callable[P, T]):
+    return _inject_wrapper(func, "socket", WebSocket)
 
-        return wrap_injection(
-            func=func,
-            is_async=True,
-            additional_params=additional_params,
-            container_getter=lambda _, r: r[request_param].state.dishka_container,
-        )
-    return wrapper if func is None else wrapper(func)
+
+def _inject_wrapper(
+        func: Callable[P, T],
+        param_name: str,
+        param_annotation: Type[Request | WebSocket]
+):
+    hints = get_type_hints(func)
+
+    request_param = next(
+        (name for name in hints if name == param_name),
+        None,
+    )
+
+    if request_param:
+        additional_params = []
+    else:
+        additional_params = [Parameter(
+            name=param_name,
+            annotation=param_annotation,
+            kind=Parameter.KEYWORD_ONLY,
+        )]
+
+    return wrap_injection(
+        func=func,
+        is_async=True,
+        additional_params=additional_params,
+        container_getter=lambda _, r: r[param_name].state.dishka_container,
+    )
 
 
 class LitestarProvider(Provider):

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -8,7 +8,7 @@ __all__ = [
 
 from collections.abc import Callable
 from inspect import Parameter
-from typing import ParamSpec, TypeVar, get_type_hints, Type
+from typing import ParamSpec, TypeVar, get_type_hints
 
 from litestar import Litestar, Request, WebSocket
 from litestar.enums import ScopeType
@@ -32,7 +32,7 @@ def inject_websocket(func: Callable[P, T]):
 def _inject_wrapper(
         func: Callable[P, T],
         param_name: str,
-        param_annotation: Type[Request | WebSocket]
+        param_annotation: type[Request | WebSocket],
 ):
     hints = get_type_hints(func)
 

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from inspect import Parameter
 from typing import ParamSpec, TypeVar, get_type_hints
 
-from litestar import Litestar, Request
+from litestar import Litestar, Request, WebSocket
 from litestar.enums import ScopeType
 from litestar.types import ASGIApp, Receive, Scope, Send
 
@@ -20,44 +20,59 @@ from dishka.integrations.base import wrap_injection
 P = ParamSpec("P")
 T = TypeVar("T")
 
+def inject(func: Callable[P, T] | None = None, websocket: bool = False):
+    def wrapper(func: Callable[P, T]) -> Callable[P, T]:
+        hints = get_type_hints(func)
 
-def inject(func: Callable[P, T]) -> Callable[P, T]:
-    hints = get_type_hints(func)
-    request_param = next(
-        (name for name in hints if name == "request"),
-        None,
-    )
-    if request_param:
-        additional_params = []
-    else:
-        request_param = "request"
-        additional_params = [Parameter(
-            name=request_param,
-            annotation=Request | None,
-            kind=Parameter.KEYWORD_ONLY,
-        )]
+        request_param_name = "request" if not websocket else "socket"
+        request_param = next(
+            (name for name in hints if name == request_param_name),
+            None,
+        )
 
-    return wrap_injection(
-        func=func,
-        is_async=True,
-        additional_params=additional_params,
-        container_getter=lambda _, r: r[request_param].state.dishka_container,
-    )
+        if request_param:
+            additional_params = []
+        else:
+            request_param = request_param_name
+            request_annotation = Request | None if not websocket else WebSocket | None
+            additional_params = [Parameter(
+                name=request_param,
+                annotation=request_annotation,
+                kind=Parameter.KEYWORD_ONLY,
+            )]
+
+        return wrap_injection(
+            func=func,
+            is_async=True,
+            additional_params=additional_params,
+            container_getter=lambda _, r: r[request_param].state.dishka_container,
+        )
+    return wrapper if func is None else wrapper(func)
 
 
 class LitestarProvider(Provider):
     request = from_context(Request, scope=DIScope.REQUEST)
+    socket = from_context(WebSocket, scope=DIScope.SESSION)
 
 
 def make_add_request_container_middleware(app: ASGIApp) -> ASGIApp:
     async def middleware(scope: Scope, receive: Receive, send: Send) -> None:
-        if scope.get("type") != ScopeType.HTTP:
+        if scope.get("type") not in (ScopeType.HTTP, ScopeType.WEBSOCKET):
             await app(scope, receive, send)
             return
 
-        request = Request(scope)  # type: ignore[var-annotated]
+        if scope.get("type") == ScopeType.HTTP:
+            request = Request(scope)  # type: ignore[var-annotated]
+            context = {Request: request}
+            di_scope = DIScope.REQUEST
+
+        else:
+            request = WebSocket(scope)
+            context = {WebSocket: request}
+            di_scope = DIScope.SESSION
+
         async with request.app.state.dishka_container(
-                {Request: request},
+            context, scope=di_scope,
         ) as request_container:
             request.state.dishka_container = request_container
             await app(scope, receive, send)

--- a/tests/integrations/litestar/test_litestar_websockets.py
+++ b/tests/integrations/litestar/test_litestar_websockets.py
@@ -1,0 +1,151 @@
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from unittest.mock import Mock
+
+import pytest
+from asgi_lifespan import LifespanManager
+from litestar import Litestar, websocket_listener
+from litestar.handlers import WebsocketListener
+from litestar.testing import TestClient
+
+from dishka import make_async_container
+from dishka.integrations.litestar import (
+    FromDishka,
+    inject,
+    setup_dishka,
+)
+from ..common import (
+    APP_DEP_VALUE,
+    REQUEST_DEP_VALUE,
+    WS_DEP_VALUE,
+    AppDep,
+    RequestDep,
+    WebSocketAppProvider,
+    WebSocketDep,
+)
+
+
+@asynccontextmanager
+async def dishka_app(view, provider) -> AsyncGenerator[TestClient, None]:
+    app = Litestar([view], debug=True)
+    container = make_async_container(provider)
+    setup_dishka(container, app)
+    async with LifespanManager(app):
+        yield TestClient(app)
+    await container.close()
+
+
+@websocket_listener("/")
+@inject(websocket=True)
+async def get_with_app(
+    data: str,
+    a: FromDishka[AppDep],
+    mock: FromDishka[Mock],
+) -> str:
+    mock(a)
+    return "passed"
+
+
+class GetWithApp(WebsocketListener):
+    path = "/"
+
+    @inject(websocket=True)
+    async def on_receive(self, data: str, a: FromDishka[AppDep], mock: FromDishka[Mock]) -> str:
+        mock(a)
+        return "passed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("view", (get_with_app, GetWithApp))
+async def test_app_dependency(view, ws_app_provider: WebSocketAppProvider):
+    async with dishka_app(view, ws_app_provider) as client:
+        with client.websocket_connect("/") as connection:
+            connection.send_text("...")
+            assert connection.receive_text() == "passed"
+
+        ws_app_provider.mock.assert_called_with(APP_DEP_VALUE)
+        ws_app_provider.app_released.assert_not_called()
+    ws_app_provider.app_released.assert_called()
+
+
+
+@websocket_listener("/")
+@inject(websocket=True)
+async def get_with_request(
+    data: str,
+    a: FromDishka[RequestDep],
+    mock: FromDishka[Mock],
+) -> str:
+    mock(a)
+    return "passed"
+
+
+class GetWithRequest(WebsocketListener):
+    path = "/"
+
+    @inject(websocket=True)
+    async def on_receive(self, data: str, a: FromDishka[RequestDep], mock: FromDishka[Mock]) -> str:
+        mock(a)
+        return "passed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("view", (get_with_request, GetWithRequest))
+async def test_request_dependency(view, ws_app_provider: WebSocketAppProvider):
+    async with dishka_app(view, ws_app_provider) as client:
+        with client.websocket_connect("/") as connection:
+            connection.send_text("...")
+            assert connection.receive_text() == "passed"
+        ws_app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
+        ws_app_provider.request_released.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("view", (get_with_request, GetWithRequest))
+async def test_request_dependency2(view, ws_app_provider: WebSocketAppProvider):
+    async with dishka_app(view, ws_app_provider) as client:
+        with client.websocket_connect("/") as connection:
+            connection.send_text("...")
+            assert connection.receive_text() == "passed"
+
+        ws_app_provider.request_released.assert_called_once()
+        ws_app_provider.request_released.reset_mock()
+
+        with client.websocket_connect("/") as connection:
+            connection.send_text("...")
+            assert connection.receive_text() == "passed"
+
+        ws_app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
+        ws_app_provider.request_released.assert_called_once()
+
+
+@websocket_listener("/")
+@inject(websocket=True)
+async def get_with_websocket(
+    data: str,
+    ws: FromDishka[WebSocketDep],
+    mock: FromDishka[Mock],
+) -> str:
+    mock(ws)
+    return "passed"
+
+
+class GetWithWebsocket(WebsocketListener):
+    path = "/"
+
+    @inject(websocket=True)
+    async def on_receive(self, data: str, a: FromDishka[WebSocketDep], mock: FromDishka[Mock]) -> str:
+        mock(a)
+        return "passed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("view", (get_with_websocket, GetWithWebsocket))
+async def test_websocket_dependency(view, ws_app_provider: WebSocketAppProvider):
+    async with dishka_app(view, ws_app_provider) as client:
+        with client.websocket_connect("/") as connection:
+            connection.send_text("...")
+            assert connection.receive_text() == "passed"
+
+        ws_app_provider.mock.assert_called_with(WS_DEP_VALUE)
+        ws_app_provider.websocket_released.assert_called_once()

--- a/tests/integrations/litestar/test_litestar_websockets.py
+++ b/tests/integrations/litestar/test_litestar_websockets.py
@@ -11,8 +11,8 @@ from litestar.testing import TestClient
 from dishka import make_async_container
 from dishka.integrations.litestar import (
     FromDishka,
-    setup_dishka,
     inject_websocket,
+    setup_dishka,
 )
 from ..common import (
     APP_DEP_VALUE,
@@ -50,13 +50,18 @@ class GetWithApp(WebsocketListener):
     path = "/"
 
     @inject_websocket
-    async def on_receive(self, data: str, a: FromDishka[AppDep], mock: FromDishka[Mock]) -> str:
+    async def on_receive(
+            self,
+            data: str,
+            a: FromDishka[AppDep],
+            mock: FromDishka[Mock],
+    ) -> str:
         mock(a)
         return "passed"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("view", (get_with_app, GetWithApp))
+@pytest.mark.parametrize("view", [get_with_app, GetWithApp])
 async def test_app_dependency(view, ws_app_provider: WebSocketAppProvider):
     async with dishka_app(view, ws_app_provider) as client:
         with client.websocket_connect("/") as connection:
@@ -84,14 +89,22 @@ class GetWithRequest(WebsocketListener):
     path = "/"
 
     @inject_websocket
-    async def on_receive(self, data: str, a: FromDishka[RequestDep], mock: FromDishka[Mock]) -> str:
+    async def on_receive(
+            self,
+            data: str,
+            a: FromDishka[RequestDep],
+            mock: FromDishka[Mock],
+    ) -> str:
         mock(a)
         return "passed"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("view", (get_with_request, GetWithRequest))
-async def test_request_dependency(view, ws_app_provider: WebSocketAppProvider):
+@pytest.mark.parametrize("view", [get_with_request, GetWithRequest])
+async def test_request_dependency(
+        view,
+        ws_app_provider: WebSocketAppProvider,
+):
     async with dishka_app(view, ws_app_provider) as client:
         with client.websocket_connect("/") as connection:
             connection.send_text("...")
@@ -101,8 +114,11 @@ async def test_request_dependency(view, ws_app_provider: WebSocketAppProvider):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("view", (get_with_request, GetWithRequest))
-async def test_request_dependency2(view, ws_app_provider: WebSocketAppProvider):
+@pytest.mark.parametrize("view", [get_with_request, GetWithRequest])
+async def test_request_dependency2(
+        view,
+        ws_app_provider: WebSocketAppProvider,
+):
     async with dishka_app(view, ws_app_provider) as client:
         with client.websocket_connect("/") as connection:
             connection.send_text("...")
@@ -134,14 +150,22 @@ class GetWithWebsocket(WebsocketListener):
     path = "/"
 
     @inject_websocket
-    async def on_receive(self, data: str, a: FromDishka[WebSocketDep], mock: FromDishka[Mock]) -> str:
+    async def on_receive(
+            self,
+            data: str,
+            a: FromDishka[WebSocketDep],
+            mock: FromDishka[Mock],
+    ) -> str:
         mock(a)
         return "passed"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("view", (get_with_websocket, GetWithWebsocket))
-async def test_websocket_dependency(view, ws_app_provider: WebSocketAppProvider):
+@pytest.mark.parametrize("view", [get_with_websocket, GetWithWebsocket])
+async def test_websocket_dependency(
+        view,
+        ws_app_provider: WebSocketAppProvider,
+):
     async with dishka_app(view, ws_app_provider) as client:
         with client.websocket_connect("/") as connection:
             connection.send_text("...")

--- a/tests/integrations/litestar/test_litestar_websockets.py
+++ b/tests/integrations/litestar/test_litestar_websockets.py
@@ -11,8 +11,8 @@ from litestar.testing import TestClient
 from dishka import make_async_container
 from dishka.integrations.litestar import (
     FromDishka,
-    inject,
     setup_dishka,
+    inject_websocket,
 )
 from ..common import (
     APP_DEP_VALUE,
@@ -36,7 +36,7 @@ async def dishka_app(view, provider) -> AsyncGenerator[TestClient, None]:
 
 
 @websocket_listener("/")
-@inject(websocket=True)
+@inject_websocket
 async def get_with_app(
     data: str,
     a: FromDishka[AppDep],
@@ -49,7 +49,7 @@ async def get_with_app(
 class GetWithApp(WebsocketListener):
     path = "/"
 
-    @inject(websocket=True)
+    @inject_websocket
     async def on_receive(self, data: str, a: FromDishka[AppDep], mock: FromDishka[Mock]) -> str:
         mock(a)
         return "passed"
@@ -70,7 +70,7 @@ async def test_app_dependency(view, ws_app_provider: WebSocketAppProvider):
 
 
 @websocket_listener("/")
-@inject(websocket=True)
+@inject_websocket
 async def get_with_request(
     data: str,
     a: FromDishka[RequestDep],
@@ -83,7 +83,7 @@ async def get_with_request(
 class GetWithRequest(WebsocketListener):
     path = "/"
 
-    @inject(websocket=True)
+    @inject_websocket
     async def on_receive(self, data: str, a: FromDishka[RequestDep], mock: FromDishka[Mock]) -> str:
         mock(a)
         return "passed"
@@ -120,7 +120,7 @@ async def test_request_dependency2(view, ws_app_provider: WebSocketAppProvider):
 
 
 @websocket_listener("/")
-@inject(websocket=True)
+@inject_websocket
 async def get_with_websocket(
     data: str,
     ws: FromDishka[WebSocketDep],
@@ -133,7 +133,7 @@ async def get_with_websocket(
 class GetWithWebsocket(WebsocketListener):
     path = "/"
 
-    @inject(websocket=True)
+    @inject_websocket
     async def on_receive(self, data: str, a: FromDishka[WebSocketDep], mock: FromDishka[Mock]) -> str:
         mock(a)
         return "passed"


### PR DESCRIPTION
Add a separate inject_websocket decorator due to the special signature of litestar websocket handlers that do not require an websocket object