### PR TITLE
Align documentation text with README, fixing errors along the way

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Container itself doesn't create objects but manages their lifecycle and caches.
 It delegates object creation to providers that are passed during creation.
 
 **Provider** is a collection of functions that provide concrete objects.
-`Provider` is a class with attributes and methods, each being the result of `provide`, `alias`, or
+`Provider` is a class with attributes and methods, each being the result of `provide`, `alias`, `from_context`, or
 `decorate`.
 They can be used as provider methods, functions to assign attributes, or method decorators.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the [detailed comparison](https://dishka.readthedocs.io/en/latest/alternatives.h
 #### Key features:
 
 * **Scopes**. Any object can have a lifespan for the entire app, a single request, or even more fractionally. Many
-  frameworks either lack scopes entirely or offer only two. Here, you can define as many scopes as needed.
+  frameworks either lack scopes completely or offer only two. Here, you can define as many scopes as needed.
 * **Finalization**. Some dependencies, like database connections, need not only to be created but also carefully
   released. Many frameworks lack this essential feature.
 * **Modular providers**. Instead of creating many separate functions or one large class, you can split factories

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To learn more about scopes, see [documentation.](https://dishka.readthedocs.io/e
 ```python
 from dishka import Provider, Scope
 
+
 service_provider = Provider(scope=Scope.REQUEST)
 service_provider.provide(Service)
 service_provider.provide(DAOImpl, provides=DAO)
@@ -109,6 +110,7 @@ class ConnectionProvider(Provider):
 
 ```python
 from dishka import make_container
+
 
 container = make_container(service_provider, ConnectionProvider())
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class SomeClient:
     ...
 ```
 
-3. **Create Provider** instance and specify how to provide dependencies.
+3. **Create `Provider`** instance and specify how to provide dependencies.
 
 Providers are used only to set up factories providing your objects.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ To learn more about scopes, see [documentation.](https://dishka.readthedocs.io/e
 ```python
 from dishka import Provider, Scope
 
-
 service_provider = Provider(scope=Scope.REQUEST)
 service_provider.provide(Service)
 service_provider.provide(DAOImpl, provides=DAO)
@@ -110,7 +109,6 @@ class ConnectionProvider(Provider):
 
 ```python
 from dishka import make_container
-
 
 container = make_container(service_provider, ConnectionProvider())
 ```
@@ -202,8 +200,8 @@ All method parameters are treated as dependencies and are created using the cont
 If `provide` is applied to a class, that class itself is treated as a factory (its `__init__` parameters are analyzed).
 Remember to assign this call to an attribute; otherwise, it will be ignored.
 
-**Component** is an isolated group of providers within the same container, identified by a unique string. When a
-dependency is requested, it is only searched within the same component as its direct dependant, unless explicitly
+**Component** is an isolated group of providers within the same container, identified by a unique string.
+When a dependency is requested, it is only searched within the same component as its direct dependant, unless explicitly
 specified otherwise.
 
 This structure allows you to build different parts of the application separately without worrying about using the same

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -117,9 +117,12 @@ There are 4 special functions:
 
 Component
 ====================
-**Component** - is an isolated group of providers within the same container identified by a string. When dependency is requested it is searched only within the same component as its dependant, unless it is declared explicitly.
+**Component** is an isolated group of providers within the same container, identified by a unique string.
+When a dependency is requested, it is only searched within the same component as its direct dependant, unless explicitly
+specified otherwise.
 
-This allows you to have multiple parts of application build separately without need to think if they use same types.
+This structure allows you to build different parts of the application separately without worrying about using the same
+types.
 
 .. code-block:: python
 
@@ -140,6 +143,7 @@ This allows you to have multiple parts of application build separately without n
         @provide(scope=Scope.APP)
         def foo(self) -> int:
             return 1
+
 
     container = make_container(MainProvider(), AdditionalProvider())
     container.get(float)  # returns 0.1

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -31,27 +31,37 @@ Scope
 ===========
 
 **Scope** is a lifespan of a dependency.
-Some dependencies can live while application is running, others are created and destroyed on each request. In more rare cases you need more short-lived objects. You set a scope for your dependency when you configure how to create it.
+Some dependencies live for the entire application lifetime, while others are created and destroyed with each request.
+In more rare cases, you need more short-lived objects.
+You set a scope for each dependency when you configure how it is created.
 
-Standard scopes are (excluding skipped):
+Standard scopes are (with some skipped):
 
-    ``APP`` |rarr| ``REQUEST`` |rarr| ``ACTION`` |rarr| ``STEP``
+    ``APP`` |rarr| ``REQUEST`` |rarr| ``ACTION`` |rarr| ``STEP``.
 
-You decide when to enter and exit them, but it is done one by one. If you entered ``APP`` scope then the next step deeper will enter ``REQUEST`` scope.
+You decide when to enter and exit each scope, but this is done one by one.
+If you enter the ``APP`` scope, then the next step deeper is to enter the ``REQUEST`` scope.
 
 .. note::
-    ``APP`` scope can be used for lazy initialization of singletons, while ``REQUEST`` scope is good for processing events like HTTP-requests or messenger updates. It is unlikely that you will need other scopes
+    ``APP`` scope can be used for lazy initialization of singletons, while ``REQUEST`` scope is good for processing events like HTTP requests or messenger updates. It is unlikely that you will need other scopes
 
 
-In dishka dependencies are lazy - they are created when you first request them. If the same dependency is requested multiple times within one scope then the same instance is returned (you can disable it for each dependency separately). A created dependency is kept until you exit the scope. And in that moment it is not just dropped away, but corresponding finalization steps are done. You can enter same scope multiple times concurrently so to have multiple instances of objects you can work simultaneously.
+In Dishka dependencies are lazy — they are created when you first request them.
+If the same dependency is requested multiple times within a single scope, then the same instance is returned (you can disable it for each dependency separately).
+A created dependency is kept until you exit the scope.
+And at that moment, it is not just dropped away, but the corresponding finalization steps are done.
+You can enter same scope multiple times concurrently so that to have multiple instances of objects you can work with simultaneously.
 
-Each object can depend on other objects from the same or previous scopes. So, if you have ``Config`` with scope of *APP* and ``Connection`` with scope of *REQUEST* you cannot have an *APP*-scoped object which requires a connection, but you can have *REQUEST*-scoped object which requires a ``Connection`` or a ``Config`` (or even both).
+Each object can depend on other objects from the same or previous scopes.
+So, if you have ``Config`` with scope of *APP* and ``Connection`` with scope of *REQUEST*,
+you cannot have *APP*-scoped object which requires a connection,
+but you can have *REQUEST*-scoped object which requires a ``Connection`` or a ``Config`` (or even both).
 
-If you are developing web application, you would enter ``APP`` scope on startup, and you would ``REQUEST`` scope in each HTTP-request.
+For a web application, enter ``APP`` scope on startup and ``REQUEST`` scope for each HTTP request.
 
-You can provide your own Scopes class if you are not satisfied with standard flow.
+You can create a custom scope by defining your own ``Scope`` class if the standard scope flow doesn't fit your needs.
 
-:ref:`Read more about custom and hidden scopes<scopes>`
+:ref:`Read more about custom and skipped scopes<scopes>`
 
 Container
 ==================

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -37,7 +37,7 @@ You set a scope for each dependency when you configure how it is created.
 
 Standard scopes are (with some skipped):
 
-    ``APP`` |rarr| ``REQUEST`` |rarr| ``ACTION`` |rarr| ``STEP``.
+    ``APP`` |rarr| ``REQUEST`` |rarr| ``ACTION`` |rarr| ``STEP``
 
 You decide when to enter and exit each scope, but this is done one by one.
 If you enter the ``APP`` scope, then the next step deeper is to enter the ``REQUEST`` scope.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -66,12 +66,14 @@ You can create a custom scope by defining your own ``Scope`` class if the standa
 Container
 ==================
 
-**Container** is an object you use to get your dependency.
+**Container** is an object you use to get your dependencies.
 
-You just call ``container.get(SomeType)`` and it finds a way to get you an instance of that type. It does not create things itself, but manages their lifecycle and caches. It delegates objects creation to providers which are passed during creation.
+You simply call ``.get(SomeType)`` and it finds a way to provide you with an instance of that type.
+Container itself doesn't create objects but manages their lifecycle and caches.
+It delegates object creation to providers that are passed during creation.
 
-Each container is assigned to a certain scope. To enter the nested scope you call it and use as a context manager.
-According to scopes order container can be used to get dependencies from its and previous scopes.
+Each container is assigned to a certain scope. To enter a nested scope, you call it and use it as a context manager.
+According to the scope order, container can be used to get dependencies from its own and previous scopes.
 
 .. code-block:: python
 
@@ -83,9 +85,10 @@ According to scopes order container can be used to get dependencies from its and
         connection = request_container.get(Connection)  # REQUEST-scoped object
         config = request_container.get(Config)  # APP-scoped object
 
-Async container is working in the same manner, but you should use async context manager and await the result of get
+Async container works in the same manner, but you should use async context manager and await the result of ``.get``.
 
-Some containers are concurrently safe, others are not: it is configured when you call a context manager. For web applications it is good to have APP-scoped container thread/task-safe, but REQUEST-scoped containers do not it, and it is default behavior.
+Some containers are concurrently safe, others are not: this is configured when you call a context manager.
+For web applications, it is good to have APP-scoped container thread/task-safe, but REQUEST-scoped containers do not require it, and this is the default behavior.
 
 
 :ref:`Read more about container API<container>`

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -9,8 +9,10 @@ Let's start with some terms.
 Dependency
 ==================
 
-**Dependency** is what you need for some part of your code to work.
-If you *database gateway* needs *database connection* to execute SQL queries, then the connection is a dependency for a gateway. If your business logic class requires *database gateway* or some *api client* then *api client* and *database gateway* are dependencies for a business logic. Here the ``Client`` is a dependency, while ``Service`` is a dependant.
+**Dependency** is what you need for some parts of your code to work.
+If your *database gateway* needs *database connection* to execute SQL queries, then the connection is a dependency for a gateway.
+If your business logic class requires *database gateway* or some *api client* then *api client* and *database gateway* are dependencies for a business logic.
+Here, the ``Client`` is a dependency, while ``Service`` is a dependant.
 
 .. code-block:: python
 
@@ -18,9 +20,11 @@ If you *database gateway* needs *database connection* to execute SQL queries, th
         def __init__(self, client: Client):
             self.client = client
 
-So, dependency is just object required for some other object. Dependencies can depend on other objects, which are their dependencies.
+So, dependency is just an object required by another object. Dependencies can depend on other objects, which are their dependencies.
 
-To follow dependency injection rule, dependent object should receive their dependencies and not request themselves. The same classes can be instantiated with different values of their dependencies. At least in tests.
+To follow dependency injection rule, dependent objects should receive their dependencies and not request them themselves.
+The same classes can be instantiated with different values of their dependencies.
+At least in tests.
 
 
 Scope

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -96,7 +96,9 @@ For web applications, it is good to have APP-scoped container thread/task-safe, 
 Provider
 ===============
 
-**Provider** is an object which members are used to construct dependencies. It is a normal object, but some attributes must be marked with special decorators so they will be used by a container. To create your own provider you inherit from ``Provider`` class and instantiate it when creating a container:
+**Provider** is an object which members are used to construct dependencies.
+It is a normal object, but some attributes must be marked with special decorators so they will be used by a container.
+To create your own provider, you inherit from ``Provider`` class and instantiate it when creating a container:
 
 .. code-block:: python
 
@@ -106,10 +108,10 @@ Provider
     container = make_container(MyProvider())
 
 
-There are 3 special functions:
+There are 4 special functions:
 
 * ``@provide`` is used to declare a factory providing a dependency. It can be used with some class or as a method decorator. :ref:`Read more<provide>`
-* ``alias`` is used to allow retrieving of the same object by different type hints. :ref:`Read more<alias>`
+* ``alias`` is used to allow retrieving the same object by different type hints. :ref:`Read more<alias>`
 * ``from_context`` is used to mark a dependency as context data, which will be set manually when entering a scope. :ref:`Read more<from-context>`
 * ``@decorate`` is used to modify or wrap an object which is already configured in another ``Provider``. :ref:`Read more<decorate>`
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,20 +3,29 @@ dishka
 
 Cute DI framework with scopes and agreeable API.
 
-This library is targeting to provide only an IoC-container but make it really useful.
-If you are tired manually passing objects to create others objects which are only used to create more objects - we have a solution.
+This library provides **IoC container** that's genuinely useful.
+If you're exhausted from endlessly passing objects just to create other objects, only to have those objects create even
+more — you're not alone, and we have a solution.
+Not every project requires IoC container, but take a look at what we offer.
 
-Unlike other instruments we are not trying to solve tasks not related to dependency injection. We want to keep DI in place, not soiling you code with global variables and additional specifiers in all places.
+Unlike other tools, Dishka focuses **only**
+on dependency injection without trying to solve unrelated tasks.
+It keeps DI in place without cluttering your code with global variables and scattered specifiers.
 
-Main ideas:
+Key features:
 
-* **Scopes**. Any object can have lifespan of the whole app, single request or even more fractionally. Many frameworks do not have scopes or have only 2 of them. Here you can have as many scopes as you need.
-* **Finalization**. Some dependencies like database connections must be not only created, but carefully released. Many framework lack this essential feature
-* **Modular providers**. Instead of creating lots of separate functions or contrariwise a big single class, you can split your factories into several classes, which makes them simpler reusable.
-* **Clean dependencies**. You do not need to add custom markers to the code of dependencies so to allow library to see them. All customization is done within providers code and only borders of scopes have to deal with library API.
-* **Simple API**. You need minimum of objects to start using library. You can easily integrate it with your task framework, examples provided.
-* **Speed**. It is fast enough so you not to worry about. It is even faster than many of the analogs.
-
+* **Scopes**. Any object can have a lifespan for the entire app, a single request, or even more fractionally. Many
+  frameworks either lack scopes completely or offer only two. Here, you can define as many scopes as needed.
+* **Finalization**. Some dependencies, like database connections, need not only to be created but also carefully
+  released. Many frameworks lack this essential feature.
+* **Modular providers**. Instead of creating many separate functions or one large class, you can split factories
+  into smaller classes for easier reuse.
+* **Clean dependencies**. You don't need to add custom markers to dependency code just to make it visible to the
+  library. Customization is managed by library providers, so only scope boundaries interact with the library API.
+* **Simple API**. Only a few objects are needed to start using the library. Integration with your framework is
+  straightforward, with examples provided.
+* **Speed**. The library is fast enough that performance is not a concern. In fact, it outperforms many
+  alternatives.
 
 .. toctree::
    :hidden:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,62 +1,64 @@
 Quickstart
 ********************
 
-1. Install dishka
+1. **Install Dishka.**
 
 .. code-block:: shell
 
     pip install dishka
 
-2. Write your classes, fill type hints. Imagine, you have two classes: Service (kind of business logic) and DAO (kind of data access) and some external api client:
+2. **Define your classes with type hints.** Imagine you have two classes: ``Service`` (business logic) and
+   ``DAO`` (data access), along with an external API client:
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
    :lines: 6-21
 
-3. Create Provider instance and setup how to provide dependencies.
+3. **Create** ``Provider`` instance and specify how to provide dependencies.
 
-Providers are only used to setup all factories providing your objects.
+Providers are used only to set up factories providing your objects.
 
-We use ``scope=Scope.APP`` for dependencies which are created only once in application lifetime,
-and ``scope=Scope.REQUEST`` for those which should be recreated for each processing request/event/etc.
-To read more about scopes, refer :ref:`scopes`
+Use ``scope=Scope.APP`` for dependencies created once for the entire application lifetime,
+and ``scope=Scope.REQUEST`` for those that need to be recreated for each request, event, etc.
+To learn more about scopes, see :ref:`scopes`
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
    :lines: 24-30
 
-To provide connection we might need to write some custom code:
+To provide a connection, you might need some custom code:
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
    :lines: 33-41
 
-4. Create main ``Container`` instance passing providers, and step into ``APP`` scope.
+4. **Create main** ``Container`` instance, passing providers, and enter ``APP`` scope.
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
    :lines: 44-47
 
-5. Container holds dependencies cache and is used to retrieve them. Here, you can use ``.get`` method to access APP-scoped dependencies:
+5. **Access dependencies using container.** Container holds a cache of dependencies and is used to retrieve them.
+   You can use ``.get`` method to access ``APP``-scoped dependencies:
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
    :lines: 49-50
 
-6. You can enter and exit ``REQUEST`` scope multiple times after that using context manager:
+6. **Enter and exit** ``REQUEST`` **scope repeatedly using a context manager**:
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
    :lines: 52-60
 
-7. Close container in the end:
+7. **Close container** when done:
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
    :lines: 62
 
-8. If you are using supported framework add decorators and middleware for it.
-For more details see :ref:`integrations`
+8. **Integrate with your framework.** If you are using a supported framework, add decorators and middleware for it.
+   For more details, see :ref:`integrations`
 
 .. code-block:: python
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,7 +11,7 @@ Quickstart
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
-   :lines: 6-18
+   :lines: 6-21
 
 3. Create Provider instance and setup how to provide dependencies.
 
@@ -23,38 +23,37 @@ To read more about scopes, refer :ref:`scopes`
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
-   :lines: 20-25
+   :lines: 24-30
 
 To provide connection we might need to write some custom code:
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
-   :lines: 27-34
+   :lines: 33-41
 
 4. Create main ``Container`` instance passing providers, and step into ``APP`` scope.
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
-   :lines: 37-39
+   :lines: 44-47
 
 5. Container holds dependencies cache and is used to retrieve them. Here, you can use ``.get`` method to access APP-scoped dependencies:
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
-   :lines: 41-42
-
+   :lines: 49-50
 
 6. You can enter and exit ``REQUEST`` scope multiple times after that using context manager:
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
-   :lines: 45-53
+   :lines: 52-60
 
 7. Close container in the end:
 
 .. literalinclude:: ./quickstart_example.py
    :language: python
-   :lines: 55
+   :lines: 62
 
 8. If you are using supported framework add decorators and middleware for it.
 For more details see :ref:`integrations`
@@ -65,10 +64,12 @@ For more details see :ref:`integrations`
         FromDishka, inject, setup_dishka,
     )
 
+
     @router.get("/")
     @inject
     async def index(service: FromDishka[Service]) -> str:
         ...
+
 
     ...
     setup_dishka(container, app)

--- a/docs/quickstart_example.py
+++ b/docs/quickstart_example.py
@@ -6,25 +6,32 @@ from sqlite3 import Connection
 class DAO(Protocol):
     ...
 
+
 class Service:
     def __init__(self, dao: DAO):
         ...
+
 
 class DAOImpl(DAO):
     def __init__(self, connection: Connection):
         ...
 
+
 class SomeClient:
     ...
 
+
 from dishka import Provider, Scope
+
 
 service_provider = Provider(scope=Scope.REQUEST)
 service_provider.provide(Service)
 service_provider.provide(DAOImpl, provides=DAO)
 service_provider.provide(SomeClient, scope=Scope.APP)  # override provider scope
 
+
 from dishka import Provider, provide, Scope
+
 
 class ConnectionProvider(Provider):
     @provide(scope=Scope.REQUEST)
@@ -36,19 +43,19 @@ class ConnectionProvider(Provider):
 
 from dishka import make_container
 
+
 container = make_container(service_provider, ConnectionProvider())
 
 client = container.get(SomeClient)  # `SomeClient` has Scope.APP, so it is accessible here
 client = container.get(SomeClient)  # same instance of `SomeClient`
 
-
-# sub-container to access more short-living objects
+# subcontainer to access shorter-living objects
 with container() as request_container:
     service = request_container.get(Service)
     service = request_container.get(Service)  # same service instance
-# at this point connection will be closed as we exited context manager
+# since we exited the context manager, the connection is now closed
 
-# new sub-container to have a new lifespan for request processing
+# new subcontainer to have a new lifespan for request processing
 with container() as request_container:
     service = request_container.get(Service)  # new service instance
 


### PR DESCRIPTION
I aligned the documentation text with the corresponding sections in the README and fixed some minor errors along the way without altering the original wording.

A few questions remain:
1. What about `provide_all`?
Should we mention it in the `README` or in `concepts.rst`?

2. Should we include links in `index.rst` to the corresponding docs sections? If so, how?