### PR TITLE
Fix issue #322 and patch `__module__` in wrap_injection

### DIFF
--- a/docs/integrations/taskiq.rst
+++ b/docs/integrations/taskiq.rst
@@ -40,11 +40,19 @@ How to use
 .. code-block:: python
 
     @broker.task
-    @inject
+    @inject(patch_module=True)
     async def start(
         gateway: FromDishka[Gateway],
     ):
         ...
+
+
+.. warning::
+   In version 1.5, the ``patch_module``  parameter was added to the ``inject`` decorator, which is responsible for overriding the ``__module__`` attribute of the function that participates in the formation of ``task_name``. 
+
+   It is recommended to use the value ``patch_module=True``, to correctly generate the default ``task_name`` according to the module in which the task handler was defined. 
+
+   The default value is ``False``, for backward compatibility with versions < 1.5. In future releases, the default value may be changed to ``True``.
 
 
 4. *(optional)* Use ``TaskiqProvider()`` when creating container if you are going to use ``taskiq.TaskiqMessage`` in providers.

--- a/src/dishka/integrations/base.py
+++ b/src/dishka/integrations/base.py
@@ -156,6 +156,7 @@ def wrap_injection(
     auto_injected_func.__name__ = func.__name__
     auto_injected_func.__qualname__ = func.__qualname__
     auto_injected_func.__doc__ = func.__doc__
+    auto_injected_func.__module__ = func.__module__
     auto_injected_func.__annotations__ = new_annotations
     auto_injected_func.__signature__ = Signature(  # type: ignore[attr-defined]
         parameters=new_params,

--- a/tests/integrations/taskiq/test_taskiq.py
+++ b/tests/integrations/taskiq/test_taskiq.py
@@ -12,12 +12,10 @@ provider = Provider(scope=Scope.REQUEST)
 provider.provide(lambda: hash("dishka"), provides=int)
 
 
-@inject
 async def return_int_task(data: FromDishka[int]) -> int:
     return data
 
 
-@inject
 async def task_with_kwargs(
     _: FromDishka[int],
     **kwargs: str,
@@ -43,21 +41,52 @@ async def create_broker() -> AsyncIterator[AsyncBroker]:
 
 
 @pytest.mark.asyncio
-async def test_return_int_task() -> None:
+@pytest.mark.parametrize(
+    "task_func",
+    [
+        (inject(return_int_task)),
+        (inject(patch_module=True)(return_int_task)),
+    ],
+)
+async def test_return_int_task(task_func) -> None:
     async with create_broker() as broker:
-        task = broker.task(return_int_task)
+        task = broker.task(task_func)
         kiq = await task.kiq()
         result = await kiq.wait_result()
         assert result.return_value == hash("dishka")
 
 
 @pytest.mark.asyncio
-async def test_task_with_kwargs() -> None:
+@pytest.mark.parametrize(
+    "task_func",
+    [
+        (inject(task_with_kwargs)),
+        (inject(patch_module=True)(task_with_kwargs)),
+    ],
+)
+async def test_task_with_kwargs(task_func) -> None:
     async with create_broker() as broker:
-        task = broker.task(task_with_kwargs)
+        task = broker.task(task_func)
         kwargs = {"key": "value"}
 
         kiq = await task.kiq(**kwargs)
         result = await kiq.wait_result()
 
         assert result.return_value == kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("task_func", "default_name"),
+    [
+        (inject(return_int_task), "dishka.integrations.base:return_int_task"),
+        (
+            inject(patch_module=True)(return_int_task),
+            "integrations.taskiq.test_taskiq:return_int_task",
+        ),
+    ],
+)
+async def test_task_default_name(task_func, default_name) -> None:
+    async with create_broker() as broker:
+        task = broker.task(task_func)
+        assert task.task_name == default_name


### PR DESCRIPTION
In this PR:
1. Patch `__module__` in wrap_injection
2. Adding a new parameter  `patch_module`  to the integration with taskiq for backward compatibility.

If `patch_module`  = `False` (default) we keep the `__module__` value according to the old behavior and throw a warning, in case of `True` - `__module__` is changed according to the wrapped function value (as it works now in other integrations).