### PR TITLE
Inject aiogram handlers once

### DIFF
--- a/src/dishka/integrations/aiogram.py
+++ b/src/dishka/integrations/aiogram.py
@@ -81,7 +81,7 @@ class AutoInjectMiddleware(BaseMiddleware):
         if is_dishka_injected(old_handler.callback):
             return await handler(event, data)
 
-        _inject_handler(old_handler)
+        inject_handler(old_handler)
         return await handler(event, data)
 
 
@@ -97,11 +97,11 @@ def setup_dishka(
         observer.outer_middleware(middleware)
 
     if auto_inject:
-        callback = partial(inject_handlers, router=router)
+        callback = partial(inject_router, router=router)
         router.startup.register(callback)
 
 
-def inject_handlers(router: Router) -> None:
+def inject_router(router: Router) -> None:
     """Inject dishka to the router handlers."""
     for observer in router.observers.values():
         if observer.event_name == "update":
@@ -109,10 +109,10 @@ def inject_handlers(router: Router) -> None:
 
         for handler in observer.handlers:
             if not is_dishka_injected(handler.callback):
-                _inject_handler(handler)
+                inject_handler(handler)
 
 
-def _inject_handler(handler: HandlerObject) -> HandlerObject:
+def inject_handler(handler: HandlerObject) -> HandlerObject:
     """Inject dishka for callback in aiogram's handler."""
     # temp_handler is used to apply original __post_init__ processing
     # for callback object wrapped by injector

--- a/src/dishka/integrations/aiogram.py
+++ b/src/dishka/integrations/aiogram.py
@@ -7,6 +7,7 @@ __all__ = [
     "setup_dishka",
 ]
 
+import warnings
 from collections.abc import Awaitable, Callable, Container
 from inspect import Parameter, signature
 from typing import Any, Final, ParamSpec, TypeVar, cast
@@ -61,6 +62,14 @@ class ContainerMiddleware(BaseMiddleware):
 
 
 class AutoInjectMiddleware(BaseMiddleware):
+    def __init__(self):
+        warnings.warn(
+            f"{self.__class__.__name__} is slow, "
+            "use `setup_dishka` instead if you care about performance",
+            UserWarning,
+            stacklevel=2,
+        )
+
     async def __call__(
         self,
         handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
@@ -71,15 +80,7 @@ class AutoInjectMiddleware(BaseMiddleware):
         if is_dishka_injected(old_handler.callback):
             return await handler(event, data)
 
-        new_handler = HandlerObject(
-            callback=inject(old_handler.callback),
-            filters=old_handler.filters,
-            flags=old_handler.flags,
-        )
-        old_handler.callback = new_handler.callback
-        old_handler.params = new_handler.params
-        old_handler.varkw = new_handler.varkw
-        old_handler.awaitable = new_handler.awaitable
+        _inject_handler(old_handler)
         return await handler(event, data)
 
 
@@ -90,9 +91,29 @@ def setup_dishka(
     auto_inject: bool = False,
 ) -> None:
     middleware = ContainerMiddleware(container)
-    auto_inject_middleware = AutoInjectMiddleware()
 
     for observer in router.observers.values():
         observer.outer_middleware(middleware)
         if auto_inject and observer.event_name != "update":
-            observer.middleware(auto_inject_middleware)
+            for handler in observer.handlers:
+                if is_dishka_injected(handler.callback):
+                    continue
+                _inject_handler(handler)
+
+
+def _inject_handler(handler: HandlerObject) -> HandlerObject:
+    """Inject dishka for callback in aiogram's handler."""
+    # temp_handler is used to apply original __post_init__ processing
+    # for callback object wrapped by injector
+    temp_handler = HandlerObject(
+        callback=inject(handler.callback),
+        filters=handler.filters,
+        flags=handler.flags,
+    )
+
+    # since injector modified callback and params,
+    # we should update them in the original handler
+    handler.callback = temp_handler.callback
+    handler.params = temp_handler.params
+
+    return handler

--- a/src/dishka/integrations/aiogram.py
+++ b/src/dishka/integrations/aiogram.py
@@ -4,6 +4,8 @@ __all__ = [
     "CONTAINER_NAME",
     "FromDishka",
     "inject",
+    "inject_handler",
+    "inject_router",
     "setup_dishka",
 ]
 


### PR DESCRIPTION
The current implementation of `setup_dishka` (with autoinject enabled) uses `AutoInjectMiddleware` which does an `inject` at application runtime each time a handler is called. Which does unnecessary work and slows down the execution of the original handler.

I refined `setup_dishka` so that `inject` is done for each handler only once, at application startup.

For users who use `AutoInjectMiddleware` directly, I added a warning with a recommendation to switch to a more productive way of working.
