### PR TITLE
Add tag to start unit tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -82,7 +82,7 @@ for env in INTEGRATIONS:
         session.run(*CMD, env.get_tests())
 
 
-@nox.session(tags=["ci"])
+@nox.session(tags=["ci", "unit"])
 def unit(session: nox.Session) -> None:
     session.install(
         *INSTALL_CMD,


### PR DESCRIPTION
Encountered a problem that it is impossible to run only unit tests using nox. Added a "unit" tag that allows running only the unit tests by `nox -t unit`