### PR TITLE
Passing data from middlewares via AiogramProvider

### DIFF
--- a/docs/integrations/aiogram.rst
+++ b/docs/integrations/aiogram.rst
@@ -6,7 +6,7 @@ aiogram
 Though it is not required, you can use dishka-aiogram integration. It features:
 
 * automatic REQUEST scope management using middleware
-* passing ``TelegramObject`` object as a context data to providers for telegram events (update object fields)
+* passing ``TelegramObject`` object and ``AiogramMiddlewareData`` dict as a context data to providers for telegram events (update object fields)
 * automatic injection of dependencies into handler function
 
 Only async handlers are supported.
@@ -26,13 +26,13 @@ How to use
     )
     from dishka import make_async_container, Provider, provide, Scope
 
-2. Create provider. You can use ``aiogram.types.TelegramObject`` as a factory parameter to access on REQUEST-scope
+2. Create provider. You can use ``aiogram.types.TelegramObject`` and ``dishka.integrations.aiogram.AiogramMiddlewareData`` as a factory parameter to access on REQUEST-scope
 
 .. code-block:: python
 
     class YourProvider(Provider):
         @provide(scope=Scope.REQUEST)
-        def create_x(self, event: TelegramObject) -> X:
+        def create_x(self, event: TelegramObject, middleware_data: AiogramMiddlewareData) -> X:
              ...
 
 
@@ -59,7 +59,7 @@ How to use
     ):
 
 
-4. *(optional)* Use ``AiogramProvider()`` when creating container if you are going to use ``aiogram.types.TelegramObject`` in providers.
+4. *(optional)* Use ``AiogramProvider()`` when creating container if you are going to use ``aiogram.types.TelegramObject`` or ``dishka.integrations.aiogram.AiogramMiddlewareData`` in providers.
 
 .. code-block:: python
 

--- a/examples/integrations/aiogram_bot.py
+++ b/examples/integrations/aiogram_bot.py
@@ -5,10 +5,11 @@ import random
 from collections.abc import AsyncIterator
 
 from aiogram import Bot, Dispatcher, Router
-from aiogram.types import Message, TelegramObject, User
+from aiogram.types import Chat, Message, TelegramObject, User
 
 from dishka import Provider, Scope, make_async_container, provide
 from dishka.integrations.aiogram import (
+    AiogramMiddlewareData,
     AiogramProvider,
     FromDishka,
     inject,
@@ -27,6 +28,10 @@ class MyProvider(Provider):
     async def get_user(self, obj: TelegramObject) -> User:
         return obj.from_user
 
+    @provide(scope=Scope.REQUEST)
+    async def get_chat(self, middleware_data: AiogramMiddlewareData) -> Chat:
+        return middleware_data.event_context.chat
+
 
 # app
 
@@ -35,13 +40,14 @@ router = Router()
 
 
 @router.message()
-@inject # if auto_inject=True is specified in the setup_dishka, then you do not need to specify a decorator
+@inject  # if auto_inject=True is specified in the setup_dishka, then you do not need to specify a decorator
 async def start(
     message: Message,
     user: FromDishka[User],
     value: FromDishka[int],
+    chat: FromDishka[Chat],
 ):
-    await message.answer(f"Hello, {value}, {user.full_name}!")
+    await message.answer(f"Hello, {value}, {chat.username}, {user.full_name}!")
 
 
 async def main():

--- a/examples/integrations/aiogram_bot.py
+++ b/examples/integrations/aiogram_bot.py
@@ -29,8 +29,8 @@ class MyProvider(Provider):
         return obj.from_user
 
     @provide(scope=Scope.REQUEST)
-    async def get_chat(self, middleware_data: AiogramMiddlewareData) -> Chat:
-        return middleware_data.event_context.chat
+    async def get_chat(self, middleware_data: AiogramMiddlewareData) -> Chat | None:
+        return middleware_data.get("event_chat")
 
 
 # app
@@ -45,9 +45,10 @@ async def start(
     message: Message,
     user: FromDishka[User],
     value: FromDishka[int],
-    chat: FromDishka[Chat],
+    chat: FromDishka[Chat | None],
 ):
-    await message.answer(f"Hello, {value}, {chat.username}, {user.full_name}!")
+    chat_name = chat.username if chat else None
+    await message.answer(f"Hello, {value}, {chat_name}, {user.full_name}!")
 
 
 async def main():

--- a/src/dishka/integrations/aiogram.py
+++ b/src/dishka/integrations/aiogram.py
@@ -12,30 +12,21 @@ __all__ = [
 
 import warnings
 from collections.abc import Awaitable, Callable, Container
-from dataclasses import dataclass
 from functools import partial
 from inspect import Parameter, signature
-from typing import Any, Final, ParamSpec, TypeVar, cast
+from typing import Any, Final, NewType, ParamSpec, TypeVar, cast
 
-from aiogram import BaseMiddleware, Bot, Dispatcher, Router
+from aiogram import BaseMiddleware, Router
 from aiogram.dispatcher.event.handler import HandlerObject
-from aiogram.fsm.context import FSMContext
-from aiogram.fsm.storage.base import BaseStorage
-from aiogram.types import Chat, TelegramObject, User
+from aiogram.types import TelegramObject
 
 from dishka import AsyncContainer, FromDishka, Provider, Scope, from_context
 from .base import is_dishka_injected, wrap_injection
 
-try:
-    from aiogram.dispatcher.middlewares.user_context import EventContext
-    IS_AIOGRAM_HAS_EVENT_CONTEXT = True
-except ImportError:
-    IS_AIOGRAM_HAS_EVENT_CONTEXT = False
-
-
 P = ParamSpec("P")
 T = TypeVar("T")
 CONTAINER_NAME: Final = "dishka_container"
+AiogramMiddlewareData = NewType("AiogramMiddlewareData", dict[str, Any])
 
 
 def inject(func: Callable[P, T]) -> Callable[P, T]:
@@ -56,36 +47,6 @@ def inject(func: Callable[P, T]) -> Callable[P, T]:
     )
 
 
-# dont import from aiogram because its not available unitl v3.5.0
-@dataclass(frozen=True)
-class EventContext:
-    chat: Chat | None = None
-    user: User | None = None
-    thread_id: int | None = None
-    business_connection_id: str | None = None
-
-    @property
-    def user_id(self) -> int | None:
-        return self.user.id if self.user else None
-
-    @property
-    def chat_id(self) -> int | None:
-        return self.chat.id if self.chat else None
-
-
-@dataclass
-class AiogramMiddlewareData:
-    event: TelegramObject
-    bot: Bot
-    bots: list[Bot] | None  # with polling
-    dispatcher: Dispatcher  # with polling
-    event_context: EventContext
-    fsm_storage: BaseStorage | None  # with fsm
-    state: FSMContext | None  # with fsm and event.from_user is not None
-    raw_state: str | None  # with fsm
-    data: dict[str, Any]
-
-
 class AiogramProvider(Provider):
     event = from_context(TelegramObject, scope=Scope.REQUEST)
     middleware_data = from_context(AiogramMiddlewareData, scope=Scope.REQUEST)
@@ -101,50 +62,14 @@ class ContainerMiddleware(BaseMiddleware):
         event: TelegramObject,
         data: dict[str, Any],
     ) -> Any:
-        event_context = self._resolve_event_context(data)
-        middleware_data = self._get_middleware_data(event, event_context, data)
-
         async with self.container(
                 {
                     TelegramObject: event,
-                    AiogramMiddlewareData: middleware_data,
+                    AiogramMiddlewareData: data,
                 },
         ) as sub_container:
             data[CONTAINER_NAME] = sub_container
             return await handler(event, data)
-
-    def _resolve_event_context(self, data: dict[str, Any]) -> EventContext:
-        if IS_AIOGRAM_HAS_EVENT_CONTEXT:
-            real_event_context = data["event_context"]
-            return EventContext(
-                chat=real_event_context.chat,
-                user=real_event_context.user,
-                thread_id=real_event_context.thread_id,
-                business_connection_id=real_event_context.business_connection_id,
-            )
-
-        chat: Chat | None = data.get("event_chat")
-        user: User | None = data.get("event_from_user")
-        thread_id: int | None = data.get("event_thread_id")
-        return EventContext(chat=chat, user=user, thread_id=thread_id)
-
-    def _get_middleware_data(
-            self,
-            event: TelegramObject,
-            event_context: EventContext,
-            data: dict[str, Any],
-    ) -> AiogramMiddlewareData:
-        return AiogramMiddlewareData(
-            event=event,
-            bot=data["bot"],
-            bots=data.get("bots"),
-            dispatcher=data.get("dispatcher"),
-            event_context=event_context,
-            fsm_storage=data.get("fsm_storage"),
-            state=data.get("state"),
-            raw_state=data.get("raw_state"),
-            data=data,
-        )
 
 
 class AutoInjectMiddleware(BaseMiddleware):

--- a/src/dishka/integrations/aiogram.py
+++ b/src/dishka/integrations/aiogram.py
@@ -12,7 +12,7 @@ __all__ = [
 
 import warnings
 from collections.abc import Awaitable, Callable, Container
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from functools import partial
 from inspect import Parameter, signature
 from typing import Any, Final, ParamSpec, TypeVar, cast
@@ -115,7 +115,13 @@ class ContainerMiddleware(BaseMiddleware):
 
     def _resolve_event_context(self, data: dict[str, Any]) -> EventContext:
         if IS_AIOGRAM_HAS_EVENT_CONTEXT:
-            return EventContext(**asdict(data["event_context"]))
+            real_event_context = data["event_context"]
+            return EventContext(
+                chat=real_event_context.chat,
+                user=real_event_context.user,
+                thread_id=real_event_context.thread_id,
+                business_connection_id=real_event_context.business_connection_id,
+            )
 
         chat: Chat | None = data.get("event_chat")
         user: User | None = data.get("event_from_user")

--- a/src/dishka/integrations/aiogram.py
+++ b/src/dishka/integrations/aiogram.py
@@ -1,5 +1,6 @@
 __all__ = [
     "CONTAINER_NAME",
+    "AiogramMiddlewareData",
     "AiogramProvider",
     "AutoInjectMiddleware",
     "FromDishka",
@@ -11,16 +12,26 @@ __all__ = [
 
 import warnings
 from collections.abc import Awaitable, Callable, Container
+from dataclasses import asdict, dataclass
 from functools import partial
 from inspect import Parameter, signature
 from typing import Any, Final, ParamSpec, TypeVar, cast
 
-from aiogram import BaseMiddleware, Router
+from aiogram import BaseMiddleware, Bot, Dispatcher, Router
 from aiogram.dispatcher.event.handler import HandlerObject
-from aiogram.types import TelegramObject
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.storage.base import BaseStorage
+from aiogram.types import Chat, TelegramObject, User
 
 from dishka import AsyncContainer, FromDishka, Provider, Scope, from_context
 from .base import is_dishka_injected, wrap_injection
+
+try:
+    from aiogram.dispatcher.middlewares.user_context import EventContext
+    IS_AIOGRAM_HAS_EVENT_CONTEXT = True
+except ImportError:
+    IS_AIOGRAM_HAS_EVENT_CONTEXT = False
+
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -45,8 +56,39 @@ def inject(func: Callable[P, T]) -> Callable[P, T]:
     )
 
 
+# dont import from aiogram because its not available unitl v3.5.0
+@dataclass(frozen=True)
+class EventContext:
+    chat: Chat | None = None
+    user: User | None = None
+    thread_id: int | None = None
+    business_connection_id: str | None = None
+
+    @property
+    def user_id(self) -> int | None:
+        return self.user.id if self.user else None
+
+    @property
+    def chat_id(self) -> int | None:
+        return self.chat.id if self.chat else None
+
+
+@dataclass
+class AiogramMiddlewareData:
+    event: TelegramObject
+    bot: Bot
+    bots: list[Bot] | None  # with polling
+    dispatcher: Dispatcher  # with polling
+    event_context: EventContext
+    fsm_storage: BaseStorage | None  # with fsm
+    state: FSMContext | None  # with fsm and event.from_user is not None
+    raw_state: str | None  # with fsm
+    data: dict[str, Any]
+
+
 class AiogramProvider(Provider):
     event = from_context(TelegramObject, scope=Scope.REQUEST)
+    middleware_data = from_context(AiogramMiddlewareData, scope=Scope.REQUEST)
 
 
 class ContainerMiddleware(BaseMiddleware):
@@ -59,9 +101,44 @@ class ContainerMiddleware(BaseMiddleware):
         event: TelegramObject,
         data: dict[str, Any],
     ) -> Any:
-        async with self.container({TelegramObject: event}) as sub_container:
+        event_context = self._resolve_event_context(data)
+        middleware_data = self._get_middleware_data(event, event_context, data)
+
+        async with self.container(
+                {
+                    TelegramObject: event,
+                    AiogramMiddlewareData: middleware_data,
+                },
+        ) as sub_container:
             data[CONTAINER_NAME] = sub_container
             return await handler(event, data)
+
+    def _resolve_event_context(self, data: dict[str, Any]) -> EventContext:
+        if IS_AIOGRAM_HAS_EVENT_CONTEXT:
+            return EventContext(**asdict(data["event_context"]))
+
+        chat: Chat | None = data.get("event_chat")
+        user: User | None = data.get("event_from_user")
+        thread_id: int | None = data.get("event_thread_id")
+        return EventContext(chat=chat, user=user, thread_id=thread_id)
+
+    def _get_middleware_data(
+            self,
+            event: TelegramObject,
+            event_context: EventContext,
+            data: dict[str, Any],
+    ) -> AiogramMiddlewareData:
+        return AiogramMiddlewareData(
+            event=event,
+            bot=data["bot"],
+            bots=data.get("bots"),
+            dispatcher=data.get("dispatcher"),
+            event_context=event_context,
+            fsm_storage=data.get("fsm_storage"),
+            state=data.get("state"),
+            raw_state=data.get("raw_state"),
+            data=data,
+        )
 
 
 class AutoInjectMiddleware(BaseMiddleware):

--- a/tests/integrations/aiogram/test_aiogram.py
+++ b/tests/integrations/aiogram/test_aiogram.py
@@ -215,19 +215,13 @@ async def test_aiogram_provider_with_container_middleware(bot):
             event: FromDishka[TelegramObject],
             middleware_data: FromDishka[AiogramMiddlewareData],
     ) -> None:
-        assert event is message is middleware_data.event
+        assert event is message
 
-        event_context = middleware_data.event_context
-        assert event_context.user.id == message.from_user.id
-        assert event_context.chat.id == message.chat.id
-        assert event_context.thread_id == message.message_thread_id
-
-        data = middleware_data.data
-        assert "bot" in data
+        assert "bot" in middleware_data
         # disable_fsm=False - tests this keys
-        assert "state" in data
-        assert "raw_state" in data
-        assert "fsm_storage" in data
+        assert "state" in middleware_data
+        assert "raw_state" in middleware_data
+        assert "fsm_storage" in middleware_data
 
     async with dishka_auto_app(handler, AiogramProvider()) as dp:
         await send_message(bot, dp)


### PR DESCRIPTION
Passing data from middlewares via `AiogramProvider` for other providers. Useful if your classes need a bot instance or something other from middlewares

Example:
```python
class MyProvider(Provider):
    scope = Scope.REQUEST

    @provide
    def bot(self, middleware_data: AiogramMiddlewareData) -> Bot:
        return middleware_data["bot"]

    @provide
    def event_context(self, middleware_data: AiogramMiddlewareData) -> EventContext:
        # aiogram>=3.5.0
        return middleware_data["event_context"]
```