### PR TITLE
Inaccuracy in documentation (faststream)

### DIFF
--- a/docs/integrations/faststream.rst
+++ b/docs/integrations/faststream.rst
@@ -79,5 +79,5 @@ How to use
 
 .. code-block:: python
 
-    setup_dishka(container=container, broker=broker, auto_inject=True)
+    setup_dishka(container=container, app=app, auto_inject=True)
 

--- a/docs/integrations/taskiq.rst
+++ b/docs/integrations/taskiq.rst
@@ -58,5 +58,5 @@ How to use
 
 .. code-block:: python
 
-    setup_dishka(container=container, broker=broker)
+    setup_dishka(container=container, app=app)
 


### PR DESCRIPTION
Updated setup_dishka for faststream and taskiq

`setup_dishka` accept the faststream app, not broker
```
def setup_dishka(
        container: AsyncContainer,
        app: FastStream,
        *,
        finalize_container: bool = True,
        auto_inject: bool = False,
) -> None:
```