### PR TITLE
Add Quart integration

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -7,6 +7,7 @@ Using with frameworks
 
 There are some integrations in library, however you are not limited to them only.
 You can create custom integrations for your framework of choice.
+Some of the integrations are supported by a community, refer to their documentation as well.
 
 .. toctree::
    :hidden:
@@ -27,6 +28,7 @@ You can create custom integrations for your framework of choice.
    telebot
    adding_new
    celery
+   Quart <https://github.com/hrimov/quart-dishka>
 
 .. list-table:: Built-in frameworks integrations
    :header-rows: 1
@@ -64,6 +66,10 @@ You can create custom integrations for your framework of choice.
      -
      -
    * -  :ref:`Starlette`
+     -
+     -
+     -
+   * -  `Quart <https://github.com/hrimov/quart-dishka>`_ (:abbr:`com (Community support)`)
      -
      -
      -


### PR DESCRIPTION
Adds integration for the Quart framework, including websockets. The implementation follows the Flask integration pattern due to their similar APIs.