### PR TITLE
feature/rapidy-integration: Add `Rapidy` integration.

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -23,6 +23,7 @@ Some of the integrations are supported by a community, refer to their documentat
    flask
    grpcio
    litestar
+   rapidy
    RQ <https://github.com/prepin/dishka-rq>
    sanic
    starlette
@@ -61,6 +62,10 @@ Some of the integrations are supported by a community, refer to their documentat
    * -  :ref:`Litestar`
      -
      - `RQ <https://github.com/prepin/dishka-rq>`_ (:abbr:`com (Community support)`)
+     -
+   * -  :ref:`Rapidy`
+     -
+     -
      -
    * -  :ref:`Sanic`
      -

--- a/docs/integrations/rapidy.rst
+++ b/docs/integrations/rapidy.rst
@@ -1,0 +1,103 @@
+.. _rapidy:
+
+Rapidy
+===========================================
+
+Though it is not required, you can use dishka-rapidy integration. It features:
+
+* automatic REQUEST scope management using middleware
+* passing ``Request`` object as a context data to providers for **HTTP** requests
+* injection of dependencies into handler function using decorator
+
+
+How to use
+****************
+
+1. Import
+
+..  code-block:: python
+
+    from dishka.integrations.rapidy import (
+        DISHKA_CONTAINER_KEY,
+        FromDishka,
+        LitestarProvider,
+        inject,
+        setup_dishka,
+    )
+    from dishka import make_async_container, Provider, provide, Scope
+
+2. Create provider. You can use ``rapidy.http.Request`` as a factory parameter to access on REQUEST-scope
+
+.. code-block:: python
+
+    class YourProvider(Provider):
+        @provide(scope=Scope.REQUEST)
+        def create_x(self, request: Request) -> X:
+             ...
+
+
+3. Mark those of your handlers parameters which are to be injected with ``FromDishka[]`` and decorate them using ``@inject``
+
+.. code-block:: python
+
+    @router.get('/')
+    @inject
+    async def endpoint(
+        request: str, gateway: FromDishka[Gateway],
+    ) -> Response:
+        ...
+
+
+4. *(optional)* Use ``RapidyProvider()`` when creating container if you are going to use ``rapidy.http.Request`` in providers.
+
+.. code-block:: python
+
+    container = make_async_container(YourProvider(), RapidyProvider())
+
+
+5. *(optional)* Setup lifespan to close container on app termination
+
+.. code-block:: python
+    from dishka.integrations.rapidy import DISHKA_CONTAINER_KEY
+
+    @asynccontextmanager
+    async def lifespan(app: Rapidy):
+        yield
+        app[DISHKA_CONTAINER_KEY].close()
+
+    app = Rapidy(..., lifespan=[lifespan])
+
+
+6. Setup dishka integration.
+
+.. code-block:: python
+
+    setup_dishka(container=container, app=app)
+
+
+Websockets
+**********************
+
+.. include:: _websockets.rst
+
+Currently, the web socket logic in `Rapidy` is identical to `aiohttp`.
+
+In rapidy your view function is called once per connection and then you retrieve messages in loop.
+So, ``inject`` decorator can be only used to retrieve SESSION-scoped objects.
+To achieve REQUEST-scope you can enter in manually:
+
+.. code-block:: python
+
+    @inject
+    async def get_with_request(
+        request: Request,
+        a: FromDishka[A],  # some object with Scope.SESSION
+        container: FromDishka[AsyncContainer],  # container for Scope.SESSION
+    ) -> web.WebsocketResponse:
+        websocket = web.WebsocketResponse()
+        await websocket.prepare(request)
+
+        async for message in websocket:
+            # enter the nested scope, which is Scope.REQUEST
+            async with container() as request_container:
+                b = await request_container.get(B)  # object with Scope.REQUEST

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,6 +43,8 @@ INTEGRATIONS = [
     IntegrationEnv("aiogram_dialog", "latest"),
     IntegrationEnv("aiohttp", "393"),
     IntegrationEnv("aiohttp", "latest"),
+    IntegrationEnv("rapidy", "100"),
+    IntegrationEnv("rapidy", "latest"),
     IntegrationEnv("arq", "0250"),
     IntegrationEnv("arq", "latest"),
     IntegrationEnv("click", "817"),

--- a/requirements/rapidy-100.txt
+++ b/requirements/rapidy-100.txt
@@ -1,0 +1,2 @@
+-r test.txt
+rapidy==1.0.0

--- a/requirements/rapidy-latest.txt
+++ b/requirements/rapidy-latest.txt
@@ -1,0 +1,2 @@
+-r test.txt
+rapidy

--- a/src/dishka/integrations/rapidy.py
+++ b/src/dishka/integrations/rapidy.py
@@ -1,0 +1,118 @@
+__all__ = [
+    "FromDishka",
+    "RapidyProvider",
+    "inject",
+    "setup_dishka",
+]
+
+from collections.abc import Callable
+from inspect import Parameter
+from typing import (
+    Annotated,
+    Final,
+    ParamSpec,
+    TypeAlias,
+    TypeVar,
+    get_type_hints,
+)
+
+from aiohttp.web_app import Application
+from aiohttp.web_response import StreamResponse
+from rapidy.enums import HeaderName
+from rapidy.http import Header, Request, middleware
+from rapidy.typedefs import CallNext
+from rapidy.version import AIOHTTP_VERSION_TUPLE
+
+from dishka import AsyncContainer, FromDishka, Provider, Scope, from_context
+from dishka.integrations.base import wrap_injection
+
+if AIOHTTP_VERSION_TUPLE >= (3, 9, 0):
+    from aiohttp.web import AppKey
+
+    DISHKA_CONTAINER_KEY: Final[AppKey[AsyncContainer]] = AppKey(
+        "dishka_container", AsyncContainer)
+
+else:
+    DISHKA_CONTAINER_KEY: Final[str] = "dishka_container"
+
+UpgradeHeader: TypeAlias = Annotated[
+    str | None,
+    Header(alias=HeaderName.upgrade),
+]
+ConnectionHeader: TypeAlias = Annotated[
+    str | None,
+    Header(alias=HeaderName.connection),
+]
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def inject(func: Callable[P, T]) -> Callable[P, T]:
+    # WebSocket support will be added later
+    return _inject_wrapper(func, "request", Request)
+
+
+def _inject_wrapper(
+        func: Callable[P, T],
+        param_name: str,
+        param_annotation: type[Request],
+) -> Callable[P, T]:
+    hints = get_type_hints(
+        func,
+        # necessary because `rapidy` uses `if TYPE_CHECKING:`
+        globalns={"Request": param_annotation},
+    )
+
+    request_exists = any(value is Request for value in hints.values())
+
+    if request_exists:
+        additional_params = []
+    else:
+        additional_params = [
+            Parameter(
+                name=param_name,
+                annotation=Request,
+                kind=Parameter.KEYWORD_ONLY,
+            ),
+        ]
+
+    return wrap_injection(
+        func=func,
+        is_async=True,
+        additional_params=additional_params,
+        container_getter=lambda _, r: r[param_name][DISHKA_CONTAINER_KEY],
+    )
+
+
+class RapidyProvider(Provider):
+    request = from_context(Request, scope=Scope.SESSION)
+    # # WebSocket support will be added later.
+
+
+@middleware
+async def _middleware(
+    request: Request,
+    call_next: CallNext,
+    *,
+    upgrade_header: UpgradeHeader = None,
+    connection_header: ConnectionHeader = None,
+) -> StreamResponse:
+    container = request.app[DISHKA_CONTAINER_KEY]
+
+    if upgrade_header == "websocket" and connection_header == "Upgrade":
+        scope = Scope.SESSION
+    else:
+        scope = Scope.REQUEST
+
+    context = {Request: request}
+
+    async with container(context=context, scope=scope) as request_container:
+        request[DISHKA_CONTAINER_KEY] = request_container
+        return await call_next(request)
+
+
+def setup_dishka(container: AsyncContainer, app: Application) -> None:
+    app[DISHKA_CONTAINER_KEY] = container
+    app.middlewares.append(_middleware)

--- a/tests/integrations/rapidy/test_rapidy.py
+++ b/tests/integrations/rapidy/test_rapidy.py
@@ -1,0 +1,87 @@
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from unittest.mock import Mock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from aiohttp.web_app import Application
+from rapidy import Rapidy
+from rapidy.http import Request, get
+from rapidy.typedefs import Handler
+
+from dishka import make_async_container
+from dishka.integrations.rapidy import FromDishka, inject, setup_dishka
+from ..common import (
+    APP_DEP_VALUE,
+    REQUEST_DEP_VALUE,
+    AppDep,
+    AppProvider,
+    RequestDep,
+)
+
+
+async def get_with_app(
+        a: FromDishka[AppDep],
+        mock: FromDishka[Mock],
+) -> None:
+    mock(a)
+
+
+async def get_with_request(
+        a: FromDishka[RequestDep],
+        mock: FromDishka[Mock],
+) -> None:
+    mock(a)
+
+
+@asynccontextmanager
+async def dishka_app(
+        handler: Handler,
+        provider: AppProvider,
+) -> AsyncGenerator[TestClient[Request, Application], None]:
+    rapidy = Rapidy(http_route_handlers=[get("/")(inject(handler))])
+
+    container = make_async_container(provider)
+    setup_dishka(container, app=rapidy)
+
+    async with (
+        TestServer(rapidy) as server,
+        TestClient(server) as client,
+    ):
+        yield client
+
+    await container.close()
+
+
+@pytest.mark.asyncio
+async def test_app_dependency(app_provider: AppProvider):
+    async with dishka_app(
+            handler=get_with_app,
+            provider=app_provider,
+    ) as client:
+        await client.get("/")
+        app_provider.mock.assert_called_with(APP_DEP_VALUE)
+        app_provider.app_released.assert_not_called()
+    app_provider.app_released.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_request_dependency(app_provider: AppProvider):
+    async with dishka_app(get_with_request, app_provider) as client:
+        await client.get("/")
+        app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
+        app_provider.request_released.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_request_dependency_ext(app_provider: AppProvider):
+    async with dishka_app(get_with_request, app_provider) as client:
+        await client.get("/")
+        app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
+        app_provider.mock.reset_mock()
+        app_provider.request_released.assert_called_once()
+        app_provider.request_released.reset_mock()
+
+        await client.get("/")
+        app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
+        app_provider.request_released.assert_called_once()


### PR DESCRIPTION
# [rAPIdy](https://rapidy.dev) Integration  
![logo-teal](https://github.com/user-attachments/assets/e9a92506-9cda-48b1-9f47-c73c3d6ac244)

## 📌 What’s Included?  
This PR introduces **full integration** with https://github.com/rAPIdy-org/rAPIdy

Documentation is already included in this PR.

## 🔍 What is rAPIdy?  
[`rAPIdy`](https://github.com/rapidy-dev/rapidy) rAPIdy is designed for developers who need a fast, async-first web framework that combines the performance of aiohttp with the simplicity and modern features of frameworks like FastAPI.

## ✅ Ready to Merge  
The code is tested, the documentation is written, and the functionality is complete. Looking forward to final review and discussion.