### PR TITLE
Handle nested routers in aiogram integration

### DIFF
--- a/examples/integrations/aiogram_bot.py
+++ b/examples/integrations/aiogram_bot.py
@@ -40,8 +40,7 @@ router = Router()
 
 
 @router.message()
-# If auto_inject=True is not passed, you need to manually apply the @inject decorator
-#@inject
+@inject  # if auto_inject=True is specified in the setup_dishka, then you do not need to specify a decorator
 async def start(
     message: Message,
     user: FromDishka[User],
@@ -63,7 +62,7 @@ async def main():
         MyProvider(),
         AiogramProvider(),
     )
-    setup_dishka(container=container, router=dp, auto_inject=True)
+    setup_dishka(container=container, router=dp)
     try:
         await dp.start_polling(bot)
     finally:

--- a/examples/integrations/aiogram_bot.py
+++ b/examples/integrations/aiogram_bot.py
@@ -40,7 +40,8 @@ router = Router()
 
 
 @router.message()
-@inject  # if auto_inject=True is specified in the setup_dishka, then you do not need to specify a decorator
+# If auto_inject=True is not passed, you need to manually apply the @inject decorator
+#@inject
 async def start(
     message: Message,
     user: FromDishka[User],
@@ -62,7 +63,7 @@ async def main():
         MyProvider(),
         AiogramProvider(),
     )
-    setup_dishka(container=container, router=dp)
+    setup_dishka(container=container, router=dp, auto_inject=True)
     try:
         await dp.start_polling(bot)
     finally:

--- a/src/dishka/integrations/aiogram.py
+++ b/src/dishka/integrations/aiogram.py
@@ -108,19 +108,19 @@ def setup_dishka(
 
     if auto_inject:
         callback = partial(inject_router, router=router)
-        for sub_router in router.chain_tail:
-            sub_router.startup.register(callback)
+        router.startup.register(callback)
 
 
 def inject_router(router: Router) -> None:
     """Inject dishka to the router handlers."""
-    for observer in router.observers.values():
-        if observer.event_name == "update":
-            continue
+    for sub_router in router.chain_tail:
+        for observer in sub_router.observers.values():
+            if observer.event_name == "update":
+                continue
 
-        for handler in observer.handlers:
-            if not is_dishka_injected(handler.callback):
-                inject_handler(handler)
+            for handler in observer.handlers:
+                if not is_dishka_injected(handler.callback):
+                    inject_handler(handler)
 
 
 def inject_handler(handler: HandlerObject) -> HandlerObject:

--- a/src/dishka/integrations/aiogram.py
+++ b/src/dishka/integrations/aiogram.py
@@ -108,7 +108,8 @@ def setup_dishka(
 
     if auto_inject:
         callback = partial(inject_router, router=router)
-        router.startup.register(callback)
+        for sub_router in router.chain_tail:
+            sub_router.startup.register(callback)
 
 
 def inject_router(router: Router) -> None:

--- a/tests/integrations/aiogram/test_aiogram.py
+++ b/tests/integrations/aiogram/test_aiogram.py
@@ -111,7 +111,7 @@ async def handle_with_app(
 
 
 @pytest.mark.parametrize("app_factory", [
-    dishka_app, dishka_auto_app, dishka_auto_app_with_sub_router
+    dishka_app, dishka_auto_app, dishka_auto_app_with_sub_router,
 ])
 @pytest.mark.asyncio
 async def test_app_dependency(bot, app_provider: AppProvider, app_factory):

--- a/tests/integrations/aiogram/test_aiogram.py
+++ b/tests/integrations/aiogram/test_aiogram.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from aiogram import Bot, Dispatcher
+from aiogram import Bot, Dispatcher, Router
 from aiogram.dispatcher.event.handler import HandlerObject
 from aiogram.types import Chat, Message, TelegramObject, Update, User
 
@@ -70,6 +70,22 @@ async def dishka_auto_app(handler, provider):
     await container.close()
 
 
+@asynccontextmanager
+async def dishka_auto_app_with_sub_router(handler, provider):
+    dp = Dispatcher()
+    router = Router()
+    router.message()(handler)
+    dp.include_router(router)
+
+    container = make_async_container(provider)
+    setup_dishka(container, router=dp, auto_inject=True)
+
+    await dp.emit_startup()
+    yield dp
+    await dp.emit_shutdown()
+    await container.close()
+
+
 async def send_message(bot, dp):
     await dp.feed_update(bot, Update(
         update_id=1,
@@ -95,7 +111,7 @@ async def handle_with_app(
 
 
 @pytest.mark.parametrize("app_factory", [
-    dishka_app, dishka_auto_app,
+    dishka_app, dishka_auto_app, dishka_auto_app_with_sub_router
 ])
 @pytest.mark.asyncio
 async def test_app_dependency(bot, app_provider: AppProvider, app_factory):


### PR DESCRIPTION
When using auto inject with integration in aiogram, handlers located in nested routers were not injected, which resulted in dependencies not being passed to them.