### PR TITLE
Validation in InjectedFuncType: raise error for async container in sync context

### DIFF
--- a/src/dishka/integrations/base.py
+++ b/src/dishka/integrations/base.py
@@ -341,10 +341,7 @@ class InjectedFuncType:
             FunctionType.GENERATOR,
             FunctionType.CALLABLE,
         ):
-            message = (
-                "An async container cannot be used in a synchronous context."
-            )
-            raise InvalidInjectedFuncTypeError(message)
+            raise InvalidInjectedFuncTypeError
 
 
 _GET_AUTO_INJECTED_FUNC_DICT = {

--- a/src/dishka/integrations/base.py
+++ b/src/dishka/integrations/base.py
@@ -35,6 +35,7 @@ from dishka.container import Container
 from dishka.entities.component import DEFAULT_COMPONENT
 from dishka.entities.depends_marker import FromDishka
 from dishka.entities.key import DependencyKey, _FromComponent
+from dishka.integrations.exceptions import InvalidInjectedFuncTypeError
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -334,6 +335,16 @@ class InjectedFuncType:
     is_async_container: bool
     manage_scope: bool
     func_type: FunctionType
+
+    def __post_init__(self) -> None:
+        if self.is_async_container and self.func_type in (
+            FunctionType.GENERATOR,
+            FunctionType.CALLABLE,
+        ):
+            message = (
+                "An async container cannot be used in a synchronous context."
+            )
+            raise InvalidInjectedFuncTypeError(message)
 
 
 _GET_AUTO_INJECTED_FUNC_DICT = {

--- a/src/dishka/integrations/exceptions.py
+++ b/src/dishka/integrations/exceptions.py
@@ -1,0 +1,4 @@
+from dishka.exception_base import DishkaError
+
+
+class InvalidInjectedFuncTypeError(DishkaError): ...

--- a/src/dishka/integrations/exceptions.py
+++ b/src/dishka/integrations/exceptions.py
@@ -1,4 +1,9 @@
 from dishka.exception_base import DishkaError
 
 
-class InvalidInjectedFuncTypeError(DishkaError): ...
+class InvalidInjectedFuncTypeError(DishkaError):
+    def __str__(self) -> str:
+        return (
+            "An async container cannot be used in a synchronous context."
+        )
+

--- a/tests/integrations/base/test_wrap_injection.py
+++ b/tests/integrations/base/test_wrap_injection.py
@@ -1,0 +1,30 @@
+from collections.abc import Callable, Iterable, Iterator
+from unittest.mock import Mock
+
+import pytest
+
+from dishka import AsyncContainer, FromDishka
+from dishka.integrations.base import wrap_injection
+from dishka.integrations.exceptions import InvalidInjectedFuncTypeError
+
+
+def sync_func(mock: FromDishka[Mock]) -> None:
+    mock.some_func()
+
+
+def sync_gen(data: Iterable[int], x: FromDishka[Mock]) -> Iterator[int]:
+    for i in data:
+        yield x.some_func(i)
+
+
+@pytest.mark.parametrize("func", [sync_func, sync_gen])
+def test_invalid_injected_func_type(
+    func: Callable,
+    async_container: AsyncContainer,
+) -> None:
+    with pytest.raises(InvalidInjectedFuncTypeError):
+        wrap_injection(
+            func=func,
+            container_getter=lambda *_: async_container,
+            is_async=True,
+        )


### PR DESCRIPTION
Validate `InjectedFuncType` and raise `InvalidInjectedFuncTypeError` for invalid async container usage
Added validation in `__post_init__` of `InjectedFuncType` to prevent using an async container in a synchronous context.
Added a test case using `pytest.raises` to ensure the error is correctly triggered.

It might be worth creating a package and splitting the `base` module, also include the `exceptions` file in that package. But this will not be necessary if the integrations are taken out of the library