### PR TITLE
feat: add DishkaRouter for Litestar

### DIFF
--- a/docs/integrations/litestar.rst
+++ b/docs/integrations/litestar.rst
@@ -39,15 +39,27 @@ How to use
 
 .. code-block:: python
 
-    @router.get('/')
+    get('/')
     @inject
     async def endpoint(
         request: str, gateway: FromDishka[Gateway],
     ) -> Response:
         ...
 
+3a. *(optional)* Set route class to each of your litestar routers to enable automatic injection (it works for HTTP and Websockets)
 
-4. *(optional)* Use ``LitestarProvider()`` when creating container if you are going to use ``litestar.Request`` in providers.
+.. code-block:: python
+
+    get('/')
+    async def endpoint(
+        request: str, gateway: FromDishka[Gateway],
+    ) -> Response:
+        ...
+    r = DishkaRouter('', route_handlers=[endpoint])
+    app = Litestar(route_handlers=[r])
+
+
+1. *(optional)* Use ``LitestarProvider()`` when creating container if you are going to use ``litestar.Request`` in providers.
 
 .. code-block:: python
 

--- a/docs/integrations/litestar.rst
+++ b/docs/integrations/litestar.rst
@@ -59,7 +59,7 @@ How to use
     app = Litestar(route_handlers=[r])
 
 
-1. *(optional)* Use ``LitestarProvider()`` when creating container if you are going to use ``litestar.Request`` in providers.
+4. *(optional)* Use ``LitestarProvider()`` when creating container if you are going to use ``litestar.Request`` in providers.
 
 .. code-block:: python
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,7 +58,7 @@ INTEGRATIONS = [
     IntegrationEnv("grpcio", "1641", constraint_3_13),
     IntegrationEnv("grpcio", "1680"),
     IntegrationEnv("grpcio", "latest"),
-    IntegrationEnv("litestar", "230"),
+    IntegrationEnv("litestar", "232"),
     IntegrationEnv("litestar", "latest"),
     IntegrationEnv("sanic", "23121"),
     IntegrationEnv("sanic", "latest"),

--- a/requirements/litestar-230.txt
+++ b/requirements/litestar-230.txt
@@ -1,2 +1,0 @@
--r asgi.txt
-litestar==2.3.0

--- a/requirements/litestar-232.txt
+++ b/requirements/litestar-232.txt
@@ -1,0 +1,2 @@
+-r asgi.txt
+litestar==2.3.2

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -9,7 +9,7 @@ __all__ = [
 from collections.abc import Callable
 from functools import wraps
 from inspect import Parameter
-from typing import ParamSpec, TypeVar, get_type_hints
+from typing import ParamSpec, TypeVar, get_type_hints, override
 
 from litestar import Controller, Litestar, Request, Router, WebSocket
 from litestar.enums import ScopeType
@@ -126,6 +126,7 @@ def _resolve_value(
 class DishkaRouter(Router):
     __slots__ = ()
 
+    @override
     def register(self, value: ControllerRouterHandler) -> list[BaseRoute]:
         return super().register(_resolve_value(self, value))
 

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -7,12 +7,27 @@ __all__ = [
 ]
 
 from collections.abc import Callable
+from functools import wraps
 from inspect import Parameter
 from typing import ParamSpec, TypeVar, get_type_hints
 
-from litestar import Litestar, Request, WebSocket
+from litestar import Controller, Litestar, Request, Router, WebSocket
 from litestar.enums import ScopeType
-from litestar.types import ASGIApp, Receive, Scope, Send
+from litestar.handlers import (
+    BaseRouteHandler,
+    HTTPRouteHandler,
+    WebsocketListener,
+)
+from litestar.handlers.websocket_handlers import WebsocketListenerRouteHandler
+from litestar.handlers.websocket_handlers._utils import ListenerHandler
+from litestar.routes import BaseRoute
+from litestar.types import (
+    ASGIApp,
+    ControllerRouterHandler,
+    Receive,
+    Scope,
+    Send,
+)
 
 from dishka import AsyncContainer, FromDishka, Provider, from_context
 from dishka import Scope as DIScope
@@ -57,6 +72,62 @@ def _inject_wrapper(
         additional_params=additional_params,
         container_getter=lambda _, r: r[param_name].state.dishka_container,
     )
+
+
+def _inject_based_on_handler_type(
+    value: BaseRouteHandler,
+) -> BaseRouteHandler:
+    if isinstance(value, HTTPRouteHandler):
+        value._fn = inject(value._fn)  # noqa: SLF001
+
+    if isinstance(value, WebsocketListenerRouteHandler) and isinstance(
+        value._fn,  # noqa: SLF001
+        ListenerHandler,
+    ):
+        value = value(inject_websocket(value._fn._fn))  # noqa: SLF001
+
+    return value
+
+
+def _inject_route_handlers(
+    get_route_handlers: Callable[P, list[BaseRouteHandler]],
+) -> Callable[P, list[BaseRouteHandler]]:
+    @wraps(get_route_handlers)
+    def _wrapper(*args: P.args, **kwargs: P.kwargs) -> list[BaseRouteHandler]:
+        return [
+            _inject_based_on_handler_type(route)
+            for route in get_route_handlers(*args, **kwargs)
+        ]
+
+    return _wrapper
+
+
+def _resolve_value(
+    router: Router,
+    value: ControllerRouterHandler,
+) -> ControllerRouterHandler:
+    if isinstance(value, Router):
+        return value
+
+    if isinstance(value, BaseRouteHandler):
+        return _inject_based_on_handler_type(value)
+
+    if isinstance(value, type):
+        if issubclass(value, Controller):
+            value.get_route_handlers = _inject_route_handlers(  # type: ignore[method-assign]
+                value.get_route_handlers,
+            )
+        if issubclass(value, WebsocketListener):
+            return _inject_based_on_handler_type(value(router).to_handler())
+
+    return value
+
+
+class DishkaRouter(Router):
+    __slots__ = ()
+
+    def register(self, value: ControllerRouterHandler) -> list[BaseRoute]:
+        return super().register(_resolve_value(self, value))
 
 
 class LitestarProvider(Provider):

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -9,7 +9,7 @@ __all__ = [
 from collections.abc import Callable
 from functools import wraps
 from inspect import Parameter
-from typing import ParamSpec, TypeVar, get_type_hints, override
+from typing import ParamSpec, TypeVar, get_type_hints
 
 from litestar import Controller, Litestar, Request, Router, WebSocket
 from litestar.enums import ScopeType
@@ -126,7 +126,6 @@ def _resolve_value(
 class DishkaRouter(Router):
     __slots__ = ()
 
-    @override
     def register(self, value: ControllerRouterHandler) -> list[BaseRoute]:
         return super().register(_resolve_value(self, value))
 

--- a/tests/integrations/litestar/test_litestar_websockets.py
+++ b/tests/integrations/litestar/test_litestar_websockets.py
@@ -10,6 +10,7 @@ from litestar.testing import TestClient
 
 from dishka import make_async_container
 from dishka.integrations.litestar import (
+    DishkaRouter,
     FromDishka,
     inject_websocket,
     setup_dishka,
@@ -35,9 +36,31 @@ async def dishka_app(view, provider) -> AsyncGenerator[TestClient, None]:
     await container.close()
 
 
+@asynccontextmanager
+async def dishka_auto_app(view, provider) -> AsyncGenerator[TestClient, None]:
+    router = DishkaRouter("", route_handlers=[])
+    router.register(view)
+    app = Litestar([router], debug=True)
+    container = make_async_container(provider)
+    setup_dishka(container, app)
+    async with LifespanManager(app):
+        yield TestClient(app)
+    await container.close()
+
+
 @websocket_listener("/")
 @inject_websocket
 async def get_with_app(
+    data: str,
+    a: FromDishka[AppDep],
+    mock: FromDishka[Mock],
+) -> str:
+    mock(a)
+    return "passed"
+
+
+@websocket_listener("/")
+async def auto_get_with_app(
     data: str,
     a: FromDishka[AppDep],
     mock: FromDishka[Mock],
@@ -51,19 +74,44 @@ class GetWithApp(WebsocketListener):
 
     @inject_websocket
     async def on_receive(
-            self,
-            data: str,
-            a: FromDishka[AppDep],
-            mock: FromDishka[Mock],
+        self,
+        data: str,
+        a: FromDishka[AppDep],
+        mock: FromDishka[Mock],
+    ) -> str:
+        mock(a)
+        return "passed"
+
+
+class AutoGetWithApp(WebsocketListener):
+    path = "/"
+
+    async def on_receive(
+        self,
+        data: str,
+        a: FromDishka[AppDep],
+        mock: FromDishka[Mock],
     ) -> str:
         mock(a)
         return "passed"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("view", [get_with_app, GetWithApp])
-async def test_app_dependency(view, ws_app_provider: WebSocketAppProvider):
-    async with dishka_app(view, ws_app_provider) as client:
+@pytest.mark.parametrize(
+    ("app_factory", "view"),
+    [
+        (dishka_app, get_with_app),
+        (dishka_auto_app, auto_get_with_app),
+        (dishka_app, GetWithApp),
+        (dishka_auto_app, AutoGetWithApp),
+    ],
+)
+async def test_app_dependency(
+    app_factory,
+    view,
+    ws_app_provider: WebSocketAppProvider,
+):
+    async with app_factory(view, ws_app_provider) as client:
         with client.websocket_connect("/") as connection:
             connection.send_text("...")
             assert connection.receive_text() == "passed"
@@ -84,27 +132,59 @@ async def get_with_request(
     return "passed"
 
 
+@websocket_listener("/")
+async def auto_get_with_request(
+    data: str,
+    a: FromDishka[RequestDep],
+    mock: FromDishka[Mock],
+) -> str:
+    mock(a)
+    return "passed"
+
+
 class GetWithRequest(WebsocketListener):
     path = "/"
 
     @inject_websocket
     async def on_receive(
-            self,
-            data: str,
-            a: FromDishka[RequestDep],
-            mock: FromDishka[Mock],
+        self,
+        data: str,
+        a: FromDishka[RequestDep],
+        mock: FromDishka[Mock],
+    ) -> str:
+        mock(a)
+        return "passed"
+
+
+class AutoGetWithRequest(WebsocketListener):
+    path = "/"
+
+    async def on_receive(
+        self,
+        data: str,
+        a: FromDishka[RequestDep],
+        mock: FromDishka[Mock],
     ) -> str:
         mock(a)
         return "passed"
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("view", [get_with_request, GetWithRequest])
+@pytest.mark.parametrize(
+    ("app_factory", "view"),
+    [
+        (dishka_app, get_with_request),
+        (dishka_auto_app, auto_get_with_request),
+        (dishka_app, GetWithRequest),
+        (dishka_auto_app, AutoGetWithRequest),
+    ],
+)
 async def test_request_dependency(
-        view,
-        ws_app_provider: WebSocketAppProvider,
+    app_factory,
+    view,
+    ws_app_provider: WebSocketAppProvider,
 ):
-    async with dishka_app(view, ws_app_provider) as client:
+    async with app_factory(view, ws_app_provider) as client:
         with client.websocket_connect("/") as connection:
             connection.send_text("...")
             assert connection.receive_text() == "passed"
@@ -113,12 +193,21 @@ async def test_request_dependency(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("view", [get_with_request, GetWithRequest])
+@pytest.mark.parametrize(
+    ("app_factory", "view"),
+    [
+        (dishka_app, get_with_request),
+        (dishka_auto_app, auto_get_with_request),
+        (dishka_app, GetWithRequest),
+        (dishka_auto_app, AutoGetWithRequest),
+    ],
+)
 async def test_request_dependency2(
-        view,
-        ws_app_provider: WebSocketAppProvider,
+    app_factory,
+    view,
+    ws_app_provider: WebSocketAppProvider,
 ):
-    async with dishka_app(view, ws_app_provider) as client:
+    async with app_factory(view, ws_app_provider) as client:
         with client.websocket_connect("/") as connection:
             connection.send_text("...")
             assert connection.receive_text() == "passed"
@@ -145,27 +234,59 @@ async def get_with_websocket(
     return "passed"
 
 
+@websocket_listener("/")
+async def auto_get_with_websocket(
+    data: str,
+    ws: FromDishka[WebSocketDep],
+    mock: FromDishka[Mock],
+) -> str:
+    mock(ws)
+    return "passed"
+
+
 class GetWithWebsocket(WebsocketListener):
     path = "/"
 
     @inject_websocket
     async def on_receive(
-            self,
-            data: str,
-            a: FromDishka[WebSocketDep],
-            mock: FromDishka[Mock],
+        self,
+        data: str,
+        a: FromDishka[WebSocketDep],
+        mock: FromDishka[Mock],
     ) -> str:
         mock(a)
         return "passed"
 
 
+class AutoGetWithWebsocket(WebsocketListener):
+    path = "/"
+
+    async def on_receive(
+        self,
+        data: str,
+        ws: FromDishka[WebSocketDep],
+        mock: FromDishka[Mock],
+    ) -> str:
+        mock(ws)
+        return "passed"
+
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize("view", [get_with_websocket, GetWithWebsocket])
+@pytest.mark.parametrize(
+    ("app_factory", "view"),
+    [
+        (dishka_app, get_with_websocket),
+        (dishka_auto_app, auto_get_with_websocket),
+        (dishka_app, GetWithWebsocket),
+        (dishka_auto_app, AutoGetWithWebsocket),
+    ],
+)
 async def test_websocket_dependency(
-        view,
-        ws_app_provider: WebSocketAppProvider,
+    app_factory,
+    view,
+    ws_app_provider: WebSocketAppProvider,
 ):
-    async with dishka_app(view, ws_app_provider) as client:
+    async with app_factory(view, ws_app_provider) as client:
         with client.websocket_connect("/") as connection:
             connection.send_text("...")
             assert connection.receive_text() == "passed"


### PR DESCRIPTION
Similar to FastAPI integration, I added support for DishkaRouter in Litestar to avoid having to use @inject on every single route handler manually.

Now handlers can mark dependencies using FromDishka[...], and automatic injection will be handled via the router.

```python
from dishka.integrations.litestar import (
    FromDishka,
    LitestarProvider,
    inject,
    setup_dishka,
    DishkaRouter,
)
from litestar import Litestar, post
from litestar.response import Response

@post('/')
async def general(gateway: FromDishka[Gateway]) -> Response:
    ...

r = DishkaRouter('', route_handlers=[general])

def create_app() -> Litestar:
    app = Litestar(route_handlers=[r])
    setup_dishka(container, app)
    return app
