### PR TITLE
'TaskiqProvider' is not declared in _all_

### DIFF
--- a/src/dishka/integrations/taskiq.py
+++ b/src/dishka/integrations/taskiq.py
@@ -1,5 +1,6 @@
 __all__ = [
     "FromDishka",
+    "TaskiqProvider",
     "inject",
     "setup_dishka",
 ]


### PR DESCRIPTION
fix(integrations.taskiq): add TaskiqProvider to all