### PR TITLE
Add literal args type checking.

### DIFF
--- a/src/dishka/dependency_source/type_match.py
+++ b/src/dishka/dependency_source/type_match.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Sequence
-from typing import Any, ForwardRef, TypeVar, get_args, get_origin
+from typing import (
+    Any,
+    ForwardRef,
+    Literal,
+    TypeVar,
+    get_args,
+    get_origin,
+)
 
 from dishka._adaptix.type_tools.basic_utils import eval_forward_ref, is_generic
 from dishka.exception_base import DishkaError
@@ -55,8 +62,14 @@ class _TypeMatcher:
         if get_origin(bound1):
             raise UnsupportedGenericBoundsError(t1)
         if not isinstance(t2, TypeVar):
-            if get_origin(t2):
-                t2 = get_origin(t2)
+            origin2 = get_origin(t2)
+            if (
+                origin2 == Literal
+                and self._is_literal_same_types(t2, bound1)
+            ):
+                return True
+            if origin2:
+                t2 = origin2
             return issubclass(t2, bound1)
         if t2.__bound__:
             bound2 = eval_maybe_forward(t2.__bound__, t2)
@@ -84,6 +97,9 @@ class _TypeMatcher:
         elif t1.__constraints__:
             return self._is_constraint_broader(t1, t2)
         return False
+
+    def _is_literal_same_types(self, t_literal: Any, t: Any) -> bool:
+        return all(isinstance(arg, t) for arg in get_args(t_literal))
 
     def is_broader_or_same_type(self, t1: Any, t2: Any) -> bool:
         if t1 == t2:

--- a/tests/unit/test_type_match.py
+++ b/tests/unit/test_type_match.py
@@ -35,7 +35,7 @@ class MyEnum(enum.StrEnum):
     A = "a"
 
 
-T4 = TypeVar("T", bound=MyEnum)
+T4 = TypeVar("T4", bound=MyEnum)
 
 
 class B[T: MyEnum](Protocol):

--- a/tests/unit/test_type_match.py
+++ b/tests/unit/test_type_match.py
@@ -1,4 +1,5 @@
-from typing import Generic, TypeVar
+import enum
+from typing import Generic, Literal, Protocol, TypeVar
 
 import pytest
 
@@ -28,6 +29,17 @@ class SubC(C): ...
 
 
 class D: ...
+
+
+class MyEnum(enum.StrEnum):
+    A = "a"
+
+
+T4 = TypeVar("T", bound=MyEnum)
+
+
+class B[T: MyEnum](Protocol):
+    dep: T
 
 
 TC = TypeVar("TC", bound=C)
@@ -62,6 +74,7 @@ TSubCCD = TypeVar("TSubCCD", "C", SubC, D)
             Mutiple[AGeneric[int], AGeneric[AGeneric[str]], T2],
             False,
         ),
+        (B[T4], B[Literal[MyEnum.A]], True),
     ],
 )
 def test_is_broader_or_same_type(*, first: T, second: T, match: bool):

--- a/tests/unit/test_type_match.py
+++ b/tests/unit/test_type_match.py
@@ -1,5 +1,4 @@
-import enum
-from typing import Generic, Literal, Protocol, TypeVar
+from typing import Generic, Literal, TypeVar
 
 import pytest
 
@@ -8,6 +7,8 @@ from dishka.dependency_source.decorator import is_broader_or_same_type
 T = TypeVar("T")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
+T4 = TypeVar("T4", bound=str)
+T5 = TypeVar("T5", int, str)
 
 
 class AGeneric(Generic[T]): ...
@@ -31,15 +32,10 @@ class SubC(C): ...
 class D: ...
 
 
-class MyEnum(enum.StrEnum):
-    A = "a"
+class CGeneric(Generic[T4]): ...
 
 
-T4 = TypeVar("T4", bound=MyEnum)
-
-
-class B[T: MyEnum](Protocol):
-    dep: T
+class DGeneric(Generic[T5]): ...
 
 
 TC = TypeVar("TC", bound=C)
@@ -74,7 +70,12 @@ TSubCCD = TypeVar("TSubCCD", "C", SubC, D)
             Mutiple[AGeneric[int], AGeneric[AGeneric[str]], T2],
             False,
         ),
-        (B[T4], B[Literal[MyEnum.A]], True),
+        (CGeneric[T4], CGeneric[Literal["a"]], True),
+        (CGeneric[T4], CGeneric[Literal[1]], False),
+        (DGeneric[T5], DGeneric[Literal[1]], True),
+        (DGeneric[T5], DGeneric[Literal["a"]], True),
+        (DGeneric[T5], DGeneric[Literal[True]], True),
+        (DGeneric[T5], DGeneric[Literal["a", 1]], False),
     ],
 )
 def test_is_broader_or_same_type(*, first: T, second: T, match: bool):


### PR DESCRIPTION
Hello!

I inserted literal checking and MRE from issue #423 is now not falling in `_TypeMatcher` anymore. But instead got this :D

```
  File ".../dishka/src/dishka/container.py", line 182, in _get_unlocked
    raise NoFactoryError(key)
dishka.exceptions.NoFactoryError: Cannot find factory for (Literal[a], component=''). It is missing or has invalid scope.
      ~~~ component='', Scope.APP ~~~
   ↓  __main__.B[Literal[a]]   alias
   ↓  __main__.A[Literal[a]]   MyProvider.a
    → typing.Literal[a]        ???
```  

Is this error related to question in Issue? I'm asking, because all tests passes successful. 