### PR TITLE
feat: allow to extend container context on calling injected func

### DIFF
--- a/docs/integrations/adding_new.rst
+++ b/docs/integrations/adding_new.rst
@@ -13,7 +13,8 @@ The main points are:
    Alternatively, you can use the ``wrap_injection`` function with ``manage_scope=True`` to automate entering and exiting the request scope without relying on middleware. When enabled, ``manage_scope`` ensures that the container passed to ``wrap_injection`` enters and exits the next scope.
 
    When you use ``manage_scope=True``, you can pass ``provide_context`` function that allows to populate the container context with passed arguments. This is useful when you want to pass the function scoped arguments to other dependencies without relying on middleware.
-   ... code-block:: python
+
+   .. code-block:: python
 
        from dishka import wrap_injection, Provider, provide
 

--- a/docs/integrations/adding_new.rst
+++ b/docs/integrations/adding_new.rst
@@ -11,6 +11,28 @@ The main points are:
 2. Find a place to enter and exit request scope and how to pass the container to a handler. Usually, it is entered in a middleware and container is stored in some kind of request context. 
 
    Alternatively, you can use the ``wrap_injection`` function with ``manage_scope=True`` to automate entering and exiting the request scope without relying on middleware. When enabled, ``manage_scope`` ensures that the container passed to ``wrap_injection`` enters and exits the next scope.
+
+   When you use ``manage_scope=True``, you can pass ``provide_context`` function that allows to populate the container context with passed arguments. This is useful when you want to pass the function scoped arguments to other dependencies without relying on middleware.
+   ... code-block:: python
+
+       from dishka import wrap_injection, Provider, provide
+
+       ...
+       class AppProvider(Provider):
+           request = from_context(provides=Request, scope=Scope.REQUEST)
+
+          @provide(scope=Scope.REQUEST)
+          def request(self, request: FromDishka[Request]) -> Iterable[User]:
+              yield get_user_from_request(request)
+
+       ...
+       wrapped_func = wrap_injection(
+           func=func,
+           is_async=False,
+           manage_scope=True,
+           provide_context=lambda req: Request: {Request: req},
+        )
+
 3. Configure a decorator. The main option here is to provide a way for retrieving container. Often, need to modify handler signature adding additional parameters. It is also available.
 4. Check if you can apply decorator automatically.
 

--- a/docs/integrations/adding_new.rst
+++ b/docs/integrations/adding_new.rst
@@ -13,27 +13,6 @@ The main points are:
    Alternatively, you can use the ``wrap_injection`` function with ``manage_scope=True`` to automate entering and exiting the request scope without relying on middleware. When enabled, ``manage_scope`` ensures that the container passed to ``wrap_injection`` enters and exits the next scope.
 
    When you use ``manage_scope=True``, you can pass ``provide_context`` function that allows to populate the container context with passed arguments. This is useful when you want to pass the function scoped arguments to other dependencies without relying on middleware.
-
-   .. code-block:: python
-
-       from dishka import wrap_injection, Provider, provide
-
-       ...
-       class AppProvider(Provider):
-           request = from_context(provides=Request, scope=Scope.REQUEST)
-
-          @provide(scope=Scope.REQUEST)
-          def request(self, request: FromDishka[Request]) -> Iterable[User]:
-              yield get_user_from_request(request)
-
-       ...
-       wrapped_func = wrap_injection(
-           func=func,
-           is_async=False,
-           manage_scope=True,
-           provide_context=lambda req: Request: {Request: req},
-        )
-
 3. Configure a decorator. The main option here is to provide a way for retrieving container. Often, need to modify handler signature adding additional parameters. It is also available.
 4. Check if you can apply decorator automatically.
 

--- a/src/dishka/integrations/base.py
+++ b/src/dishka/integrations/base.py
@@ -36,7 +36,7 @@ from dishka.entities.component import DEFAULT_COMPONENT
 from dishka.entities.depends_marker import FromDishka
 from dishka.entities.key import DependencyKey, _FromComponent
 from dishka.integrations.exceptions import (
-    InvalidInjectedFuncProvideContextError,
+    ImproperProvideContextUsageError,
     InvalidInjectedFuncTypeError,
 )
 
@@ -94,7 +94,7 @@ def _get_auto_injected_async_gen(
     provide_context: ProvideContext | None = None,
 ) -> Callable[P, AsyncIterator[T]]:
     if provide_context is not None:
-        raise InvalidInjectedFuncProvideContextError
+        raise ImproperProvideContextUsageError
 
     async def auto_injected_generator(
         *args: P.args,
@@ -153,7 +153,7 @@ def _get_auto_injected_async_func(
     provide_context: ProvideContext | None = None,
 ) -> Callable[P, Awaitable[T]]:
     if provide_context is not None:
-        raise InvalidInjectedFuncProvideContextError
+        raise ImproperProvideContextUsageError
 
     async def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         container = container_getter(args, kwargs)
@@ -207,7 +207,7 @@ def _get_auto_injected_sync_gen(
     provide_context: ProvideContext | None = None,
 ) -> Callable[P, Iterator[T]]:
     if provide_context is not None:
-        raise InvalidInjectedFuncProvideContextError
+        raise ImproperProvideContextUsageError
 
     def auto_injected_generator(
         *args: P.args,
@@ -258,7 +258,7 @@ def _get_auto_injected_sync_func(
     provide_context: ProvideContext | None = None,
 ) -> Callable[P, T]:
     if provide_context is not None:
-        raise InvalidInjectedFuncProvideContextError
+        raise ImproperProvideContextUsageError
 
     def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         container = container_getter(args, kwargs)
@@ -311,7 +311,7 @@ def _get_auto_injected_sync_container_async_gen(
     provide_context: ProvideContext | None = None,
 ) -> Callable[P, AsyncIterator[T]]:
     if provide_context is not None:
-        raise InvalidInjectedFuncProvideContextError
+        raise ImproperProvideContextUsageError
 
     async def auto_injected_generator(
         *args: P.args,
@@ -363,7 +363,7 @@ def _get_auto_injected_sync_container_async_func(
     provide_context: ProvideContext | None = None,
 ) -> Callable[P, T]:
     if provide_context is not None:
-        raise InvalidInjectedFuncProvideContextError
+        raise ImproperProvideContextUsageError
 
     async def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         container = container_getter(args, kwargs)

--- a/src/dishka/integrations/base.py
+++ b/src/dishka/integrations/base.py
@@ -91,7 +91,11 @@ def _get_auto_injected_async_gen(
     additional_params: Sequence[Parameter],
     dependencies: dict[str, DependencyKey],
     func: Callable[P, AsyncIterator[T]],
+    provide_context: ProvideContext | None = None,
 ) -> Callable[P, AsyncIterator[T]]:
+    if provide_context is not None:
+        raise InvalidInjectedFuncProvideContextError
+
     async def auto_injected_generator(
         *args: P.args,
         **kwargs: P.kwargs,
@@ -146,7 +150,11 @@ def _get_auto_injected_async_func(
     additional_params: Sequence[Parameter],
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Awaitable[T]],
+    provide_context: ProvideContext | None = None,
 ) -> Callable[P, Awaitable[T]]:
+    if provide_context is not None:
+        raise InvalidInjectedFuncProvideContextError
+
     async def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         container = container_getter(args, kwargs)
         for param in additional_params:
@@ -196,7 +204,11 @@ def _get_auto_injected_sync_gen(
     additional_params: Sequence[Parameter],
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Iterator[T]],
+    provide_context: ProvideContext | None = None,
 ) -> Callable[P, Iterator[T]]:
+    if provide_context is not None:
+        raise InvalidInjectedFuncProvideContextError
+
     def auto_injected_generator(
         *args: P.args,
         **kwargs: P.kwargs,
@@ -243,7 +255,11 @@ def _get_auto_injected_sync_func(
     additional_params: Sequence[Parameter],
     dependencies: dict[str, DependencyKey],
     func: Callable[P, T],
+    provide_context: ProvideContext | None = None,
 ) -> Callable[P, T]:
+    if provide_context is not None:
+        raise InvalidInjectedFuncProvideContextError
+
     def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         container = container_getter(args, kwargs)
         for param in additional_params:
@@ -292,7 +308,11 @@ def _get_auto_injected_sync_container_async_gen(
     additional_params: Sequence[Parameter],
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Iterator[T]],
+    provide_context: ProvideContext | None = None,
 ) -> Callable[P, AsyncIterator[T]]:
+    if provide_context is not None:
+        raise InvalidInjectedFuncProvideContextError
+
     async def auto_injected_generator(
         *args: P.args,
         **kwargs: P.kwargs,
@@ -340,7 +360,11 @@ def _get_auto_injected_sync_container_async_func(
     additional_params: Sequence[Parameter],
     dependencies: dict[str, DependencyKey],
     func: Callable[P, T],
+    provide_context: ProvideContext | None = None,
 ) -> Callable[P, T]:
+    if provide_context is not None:
+        raise InvalidInjectedFuncProvideContextError
+
     async def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         container = container_getter(args, kwargs)
         for param in additional_params:
@@ -574,18 +598,13 @@ def wrap_injection(
     )
     get_auto_injected_func = _GET_AUTO_INJECTED_FUNC_DICT[injected_func_type]
 
-    kwargs = {
-        "func": func,
-        "dependencies": dependencies,
-        "additional_params": additional_params,
-        "container_getter": container_getter,
-    }
-    if provide_context is not None:
-        if not manage_scope:
-            raise InvalidInjectedFuncProvideContextError
-        kwargs["provide_context"] = provide_context
-
-    auto_injected_func = get_auto_injected_func(**kwargs)
+    auto_injected_func = get_auto_injected_func(
+        func=func,
+        provide_context=provide_context,
+        dependencies=dependencies,
+        additional_params=additional_params,
+        container_getter=container_getter,
+    )
 
     auto_injected_func.__dishka_orig_func__ = func
     auto_injected_func.__dishka_injected__ = True  # type: ignore[attr-defined]

--- a/src/dishka/integrations/exceptions.py
+++ b/src/dishka/integrations/exceptions.py
@@ -6,3 +6,9 @@ class InvalidInjectedFuncTypeError(DishkaError):
         return (
             "An async container cannot be used in a synchronous context."
         )
+
+class InvalidInjectedFuncProvideContextError(DishkaError):
+    def __str__(self) -> str:
+        return (
+            "provide_context is not supported without manage_scope=True."
+        )

--- a/src/dishka/integrations/exceptions.py
+++ b/src/dishka/integrations/exceptions.py
@@ -3,12 +3,9 @@ from dishka.exception_base import DishkaError
 
 class InvalidInjectedFuncTypeError(DishkaError):
     def __str__(self) -> str:
-        return (
-            "An async container cannot be used in a synchronous context."
-        )
+        return "An async container cannot be used in a synchronous context."
 
-class InvalidInjectedFuncProvideContextError(DishkaError):
+
+class ImproperProvideContextUsageError(DishkaError):
     def __str__(self) -> str:
-        return (
-            "provide_context is not supported without manage_scope=True."
-        )
+        return "provide_context can only be used with manage_scope=True."

--- a/tests/integrations/base/test_wrap_injection_provide_context.py
+++ b/tests/integrations/base/test_wrap_injection_provide_context.py
@@ -1,0 +1,95 @@
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator
+from inspect import isasyncgenfunction, isgeneratorfunction
+
+import pytest
+
+from dishka.async_container import AsyncContainer
+from dishka.container import Container
+from dishka.entities.depends_marker import FromDishka
+from dishka.integrations.base import wrap_injection
+from dishka.integrations.exceptions import (
+    InvalidInjectedFuncProvideContextError,
+)
+from tests.integrations.common import ContextDep
+
+
+def sync_func(context: FromDishka[ContextDep]) -> str:
+    return context
+
+
+def sync_gen(
+    data: Iterable[int],
+    context: FromDishka[ContextDep],
+) -> Iterator[str]:
+    for i in data:
+        yield f"{i}. {context}"
+
+
+async def async_func(context: FromDishka[ContextDep]) -> str:
+    return context
+
+
+async def async_gen(
+    data: Iterable[int],
+    context: FromDishka[ContextDep],
+) -> AsyncIterator[str]:
+    for i in data:
+        yield f"{i}. {context}"
+
+
+@pytest.mark.parametrize("func", [sync_func, sync_gen])
+def test_sync_provide_context(func: Callable, container: Container) -> None:
+    wrapped_func = wrap_injection(
+        func=func,
+        container_getter=lambda *_: container,
+        is_async=False,
+        manage_scope=True,
+        provide_context=lambda *_: {ContextDep: "context"},
+    )
+
+    if isgeneratorfunction(func):
+        result = list(wrapped_func([1, 2]))
+        assert result == ["1. context", "2. context"]
+    else:
+        result = wrapped_func()
+        assert result == "context"
+
+    with pytest.raises(InvalidInjectedFuncProvideContextError):
+        wrap_injection(
+            func=func,
+            container_getter=lambda *_: container,
+            is_async=False,
+            manage_scope=False,
+            provide_context=lambda *_: {ContextDep: "context"},
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("func", [async_func, async_gen])
+async def test_async_provide_context(
+    func: Callable,
+    async_container: AsyncContainer,
+) -> None:
+    wrapped_func = wrap_injection(
+        func=func,
+        container_getter=lambda *_: async_container,
+        is_async=True,
+        manage_scope=True,
+        provide_context=lambda *_: {ContextDep: "context"},
+    )
+
+    if isasyncgenfunction(func):
+        result = [item async for item in wrapped_func([1, 2])]
+        assert result == ["1. context", "2. context"]
+    else:
+        result = await wrapped_func()
+        assert result == "context"
+
+    with pytest.raises(InvalidInjectedFuncProvideContextError):
+        wrap_injection(
+            func=func,
+            container_getter=lambda *_: async_container,
+            is_async=True,
+            manage_scope=False,
+            provide_context=lambda *_: {ContextDep: "context"},
+        )

--- a/tests/integrations/base/test_wrap_injection_provide_context.py
+++ b/tests/integrations/base/test_wrap_injection_provide_context.py
@@ -7,9 +7,7 @@ from dishka.async_container import AsyncContainer
 from dishka.container import Container
 from dishka.entities.depends_marker import FromDishka
 from dishka.integrations.base import wrap_injection
-from dishka.integrations.exceptions import (
-    InvalidInjectedFuncProvideContextError,
-)
+from dishka.integrations.exceptions import ImproperProvideContextUsageError
 from tests.integrations.common import ContextDep
 
 
@@ -57,7 +55,7 @@ def test_sync_provide_context(func: Callable, container: Container) -> None:
 
 @pytest.mark.parametrize("func", [sync_func, sync_gen])
 def test_invalid_provide_context(func: Callable, container: Container) -> None:
-    with pytest.raises(InvalidInjectedFuncProvideContextError):
+    with pytest.raises(ImproperProvideContextUsageError):
         wrap_injection(
             func=func,
             container_getter=lambda *_: container,
@@ -95,7 +93,7 @@ async def test_invalid_async_provide_context(
     func: Callable,
     async_container: AsyncContainer,
 ) -> None:
-    with pytest.raises(InvalidInjectedFuncProvideContextError):
+    with pytest.raises(ImproperProvideContextUsageError):
         wrap_injection(
             func=func,
             container_getter=lambda *_: async_container,

--- a/tests/integrations/base/test_wrap_injection_provide_context.py
+++ b/tests/integrations/base/test_wrap_injection_provide_context.py
@@ -54,6 +54,9 @@ def test_sync_provide_context(func: Callable, container: Container) -> None:
         result = wrapped_func()
         assert result == "context"
 
+
+@pytest.mark.parametrize("func", [sync_func, sync_gen])
+def test_invalid_provide_context(func: Callable, container: Container) -> None:
     with pytest.raises(InvalidInjectedFuncProvideContextError):
         wrap_injection(
             func=func,
@@ -85,6 +88,13 @@ async def test_async_provide_context(
         result = await wrapped_func()
         assert result == "context"
 
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("func", [async_func, async_gen])
+async def test_invalid_async_provide_context(
+    func: Callable,
+    async_container: AsyncContainer,
+) -> None:
     with pytest.raises(InvalidInjectedFuncProvideContextError):
         wrap_injection(
             func=func,

--- a/tests/integrations/common.py
+++ b/tests/integrations/common.py
@@ -28,6 +28,7 @@ class AppProvider(Provider):
         self.app_released = Mock()
         self.request_released = Mock()
         self.websocket_released = Mock()
+        self.db_session_released = Mock()
         self.mock = Mock()
         self.app_mock = AppMock(Mock())
 
@@ -49,6 +50,7 @@ class AppProvider(Provider):
     @provide(scope=Scope.REQUEST)
     def user(self, context: FromDishka[ContextDep]) -> Iterable[UserDep]:
         yield f"user_id.from_context({context})"
+        self.db_session_released()
 
     @provide(scope=Scope.REQUEST)
     def get_mock(self) -> Mock:

--- a/tests/integrations/common.py
+++ b/tests/integrations/common.py
@@ -3,8 +3,10 @@ from typing import NewType
 from unittest.mock import Mock
 
 from dishka import Provider, Scope, from_context, provide
+from dishka.entities.depends_marker import FromDishka
 
 ContextDep = NewType("ContextDep", str)
+UserDep = NewType("UserDep", str)
 
 AppDep = NewType("AppDep", str)
 APP_DEP_VALUE = "APP"
@@ -43,6 +45,10 @@ class AppProvider(Provider):
     def websocket(self) -> Iterable[WebSocketDep]:
         yield WS_DEP_VALUE
         self.websocket_released()
+
+    @provide(scope=Scope.REQUEST)
+    def user(self, context: FromDishka[ContextDep]) -> Iterable[UserDep]:
+        yield f"user_id.from_context({context})"
 
     @provide(scope=Scope.REQUEST)
     def get_mock(self) -> Mock:

--- a/tests/integrations/common.py
+++ b/tests/integrations/common.py
@@ -2,7 +2,9 @@ from collections.abc import Iterable
 from typing import NewType
 from unittest.mock import Mock
 
-from dishka import Provider, Scope, provide
+from dishka import Provider, Scope, from_context, provide
+
+ContextDep = NewType("ContextDep", str)
 
 AppDep = NewType("AppDep", str)
 APP_DEP_VALUE = "APP"
@@ -17,6 +19,8 @@ AppMock = NewType("AppMock", Mock)
 
 
 class AppProvider(Provider):
+    context = from_context(provides=ContextDep, scope=Scope.REQUEST)
+
     def __init__(self) -> None:
         super().__init__()
         self.app_released = Mock()


### PR DESCRIPTION
Relates #450 

## Description
In this PR `wrap_injection` function accepts `provide_context` that allows to provide injected variables on injected function call
It could be useful for building integrations where there is no support for middleware and/or request hooks, as well as for more granular deeper scopes
it works only with `manage_scope=Tru`

## Notes (UPD)
1. I tried not create @ovlerload to minimize the code, but check it during runtime with the corresponding error message
2. [x] Shall I add documentation?
3. [x] There is a problem with function `wrap_injection` complexity - C901 and PLR0912 (needs to discuss)
