### PR TITLE
Fix/flask integration teardown container check

### DIFF
--- a/src/dishka/integrations/flask.py
+++ b/src/dishka/integrations/flask.py
@@ -40,7 +40,8 @@ class ContainerMiddleware:
         g.dishka_container = g.dishka_container_wrapper.__enter__()
 
     def exit_request(self, *_args: Any, **_kwargs: Any) -> None:
-        if hasattr(g, "dishka_container"):
+        dishka_container = getattr(g, "dishka_container", None)
+        if dishka_container is not None:
             g.dishka_container.close()
 
 

--- a/src/dishka/integrations/flask.py
+++ b/src/dishka/integrations/flask.py
@@ -40,7 +40,8 @@ class ContainerMiddleware:
         g.dishka_container = g.dishka_container_wrapper.__enter__()
 
     def exit_request(self, *_args: Any, **_kwargs: Any) -> None:
-        g.dishka_container.close()
+        if hasattr(g, "dishka_container"):
+            g.dishka_container.close()
 
 
 def _inject_routes(scaffold: Scaffold) -> None:

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -1,10 +1,15 @@
-from contextlib import contextmanager
+from collections.abc import Callable, Generator, Iterable
+from contextlib import AbstractContextManager, contextmanager
+from typing import Any, Literal
 from unittest.mock import Mock
 
 import pytest
-from flask import Flask
+from flask import Flask, g
+from flask.typing import (
+    BeforeRequestCallable,
+)
 
-from dishka import make_container
+from dishka import Provider, make_container
 from dishka.integrations.flask import FromDishka, inject, setup_dishka
 from ..common import (
     APP_DEP_VALUE,
@@ -14,9 +19,17 @@ from ..common import (
     RequestDep,
 )
 
+type AppFactory = Callable[
+    ...,
+    AbstractContextManager[Flask],
+]
+
 
 @contextmanager
-def dishka_app(view, provider):
+def dishka_app(
+    view: Callable[..., Any],
+    provider: Provider,
+) -> Generator[Flask, None, None]:
     app = Flask(__name__)
     app.get("/")(inject(view))
     container = make_container(provider)
@@ -26,7 +39,10 @@ def dishka_app(view, provider):
 
 
 @contextmanager
-def dishka_auto_app(view, provider):
+def dishka_auto_app(
+    view: Callable[..., Any],
+    provider: Provider,
+) -> Generator[Flask, None, None]:
     app = Flask(__name__)
     app.get("/")(view)
     container = make_container(provider)
@@ -35,17 +51,43 @@ def dishka_auto_app(view, provider):
     container.close()
 
 
+@contextmanager
+def dishka_app_with_lifecycle_hooks(
+    view: Callable[..., Any],
+    provider: Provider,
+    *,
+    before_request: Iterable[BeforeRequestCallable] | None = None,
+) -> Generator[Flask, None, None]:
+    app = Flask(__name__)
+    if before_request is not None:
+        for func in before_request:
+            app.before_request(func)
+
+    app.get("/")(view)
+    container = make_container(provider)
+    setup_dishka(container=container, app=app, auto_inject=True)
+    yield app
+    container.close()
+
+
 def handle_with_app(
-        a: FromDishka[AppDep],
-        mock: FromDishka[Mock],
+    a: FromDishka[AppDep],
+    mock: FromDishka[Mock],
 ) -> None:
     mock(a)
 
 
-@pytest.mark.parametrize("app_factory", [
-    dishka_app, dishka_auto_app,
-])
-def test_app_dependency(app_provider: AppProvider, app_factory):
+@pytest.mark.parametrize(
+    "app_factory",
+    [
+        dishka_app,
+        dishka_auto_app,
+    ],
+)
+def test_app_dependency(
+    app_provider: AppProvider,
+    app_factory: AppFactory,
+) -> None:
     with app_factory(handle_with_app, app_provider) as app:
         app.test_client().get("/")
         app_provider.mock.assert_called_with(APP_DEP_VALUE)
@@ -54,20 +96,20 @@ def test_app_dependency(app_provider: AppProvider, app_factory):
 
 
 def handle_with_request(
-        a: FromDishka[RequestDep],
-        mock: FromDishka[Mock],
+    a: FromDishka[RequestDep],
+    mock: FromDishka[Mock],
 ) -> None:
     mock(a)
 
 
-def test_request_dependency(app_provider: AppProvider):
+def test_request_dependency(app_provider: AppProvider) -> None:
     with dishka_app(handle_with_request, app_provider) as app:
         app.test_client().get("/")
         app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
         app_provider.request_released.assert_called_once()
 
 
-def test_request_dependency2(app_provider: AppProvider):
+def test_request_dependency2(app_provider: AppProvider) -> None:
     with dishka_app(handle_with_request, app_provider) as app:
         app.test_client().get("/")
         app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
@@ -79,3 +121,36 @@ def test_request_dependency2(app_provider: AppProvider):
         app.test_client().get("/")
         app_provider.mock.assert_called_with(REQUEST_DEP_VALUE)
         app_provider.request_released.assert_called_once()
+
+
+def test_before_request_adds_container_to_flask_g(
+    app_provider: AppProvider,
+) -> None:
+    with (
+        dishka_app(
+            handle_with_request,
+            app_provider,
+        ) as app,
+        app.test_request_context(),
+    ):
+        app.test_client().get("/")
+        assert hasattr(g, "dishka_container")
+
+
+def before_request_interceptor(*args, **kwargs) -> Literal["OK"]:
+    return "OK"
+
+
+def test_teardown_skips_container_close_when_not_in_flask_g(
+    app_provider: AppProvider,
+) -> None:
+    with (
+        dishka_app_with_lifecycle_hooks(
+            handle_with_request,
+            app_provider,
+            before_request=(before_request_interceptor,),
+        ) as app,
+        app.test_request_context(),
+    ):
+        app.test_client().get("/")
+        assert not hasattr(g, "dishka_container")

--- a/tests/integrations/flask/test_flask.py
+++ b/tests/integrations/flask/test_flask.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Generator, Iterable
 from contextlib import AbstractContextManager, contextmanager
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 from unittest.mock import Mock
 
 import pytest
@@ -19,7 +19,7 @@ from ..common import (
     RequestDep,
 )
 
-type AppFactory = Callable[
+AppFactory: TypeAlias = Callable[
     ...,
     AbstractContextManager[Flask],
 ]


### PR DESCRIPTION
### Problem
The Flask integration currently has an issue when `before_request` hooks are registered before `setup_dishka()`. If a `before_request` hook returns a response early, dishka never gets a chance to add `dishka_container` to `flask.g`. Later, during `teardown_appcontext`, dishka attempts to access `flask.g.dishka_container` to close it, which raises an `AttributeError`.

### Current Workaround vs. Limitations
While this can be avoided by calling `setup_dishka()` before registering other hooks, this approach has limitations:

- The `auto_inject` feature requires calling `setup_dishka()` after registering all blueprints
- This may conflict with requirements for other hooks that need to be registered before blueprints
- Creates an ordering constraint that's difficult to satisfy in complex applications

### Solution
This PR adds a simple guard to check if `flask.g` has `dishka_container` before attempting to close it, preventing the `AttributeError`.

### Additional Changes

- Added missing type hints to Flask integration tests for better code quality
- Added tests to verify proper `dishka_container` lifecycle handling in `flask.g`

Happy to drop the type hint improvements if they're not needed for this PR.