### PR TITLE
Proper support for remove_depends=False

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,21 @@
 [mypy]
 files = src/dishka
-exclude = ^src/dishka/(_adaptix|integrations)/
+exclude = (?x)(
+    ^src/dishka/_adaptix/
+    |^src/dishka/integrations/(
+        aiohttp
+        |aiogram
+        |celery
+        |click
+        |fastapi
+        |faststream
+        |grpcio
+        |litestar
+        |sanic
+        |starlette
+        |taskiq
+        |telebot
+    ).py)
 
 strict = true
 strict_bytes = true

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -25,6 +25,7 @@ lint.ignore = [
     "PLR0913",
     "SIM103",
     "ISC003",
+    "COM812",
 
     # identitcal by code != identical by meaning
     "SIM114",

--- a/tests/integrations/base/test_iter_dependencies_to_inject.py
+++ b/tests/integrations/base/test_iter_dependencies_to_inject.py
@@ -1,0 +1,92 @@
+from inspect import signature
+from unittest.mock import Mock
+
+import pytest
+
+from dishka import FromDishka
+from dishka.integrations.base import _iter_dependencies_to_inject
+from tests.integrations.common import AppMock
+
+Dep1 = FromDishka[Mock]
+Dep2 = FromDishka[AppMock]
+
+
+def pos_or_kw(i: int, d1: Dep1, d2: Dep2, j: int = 0): ...
+
+
+def kw_only(i: int, *, d1: Dep1, d2: Dep2, j: int = 0): ...
+
+
+def mixed(i: int, d1: Dep1, *, d2: Dep2, j: int = 0): ...
+
+
+def pos_only(i: int, d1: Dep1, d2: Dep2, /, j: int = 0): ...
+
+
+def pos_only_d1(i: int, d1: Dep1, /, d2: Dep2, j: int = 0): ...
+
+
+def var_args(i: int, d1: Dep1, *d2: Dep2, j: int = 0): ...
+
+
+def var_kwargs(i: int, d1: Dep1, j: int = 0, **d2: Dep2): ...
+
+
+def var_args_kwargs(i: int, *d1: Dep1, j: int = 0, **d2: Dep2): ...
+
+
+def get_injected_names_factory(func):
+    params = list(signature(func).parameters.values())
+    deps = {"d1": Mock(), "d2": AppMock(Mock())}
+
+    def get_injected_names(*args, **kw):
+        named_deps = _iter_dependencies_to_inject(deps, params, *args, **kw)
+        return [name for name, _ in named_deps]
+
+    return get_injected_names
+
+
+@pytest.mark.parametrize("func", [pos_or_kw, kw_only, mixed])
+def test_dont_pass_dependencies(func):
+    get_injected_names = get_injected_names_factory(func)
+    # Both dependencies injected
+    assert get_injected_names(1) == ["d1", "d2"]
+    assert get_injected_names(2, j=9) == ["d1", "d2"]
+
+
+@pytest.mark.parametrize("func", [pos_or_kw, kw_only, mixed])
+def test_pass_dependencies_by_name(func):
+    get_injected_names = get_injected_names_factory(func)
+    # d1 passed by name, d2 injected
+    assert get_injected_names(1, d1=Mock()) == ["d2"]
+    assert get_injected_names(2, d1=Mock(), j=9) == ["d2"]
+    # d2 passed by name, d1 injected
+    assert get_injected_names(3, d2=Mock()) == ["d1"]
+    assert get_injected_names(4, d2=Mock(), j=9) == ["d1"]
+    # Both dependencies passed by name, no injection
+    assert get_injected_names(1, d1=Mock(), d2=Mock()) == []
+    assert get_injected_names(2, d1=Mock(), d2=Mock(), j=9) == []
+
+
+@pytest.mark.parametrize("func", [pos_or_kw, mixed])
+def test_pass_dependencies_by_position(func):
+    get_injected_names = get_injected_names_factory(func)
+    # d1 passed positionally, d2 injected
+    assert get_injected_names(1, Mock()) == ["d2"]
+    assert get_injected_names(2, Mock(), j=9) == ["d2"]
+    # d1 passed positionally, d2 passed by name, no injection
+    assert get_injected_names(2, Mock(), d2=Mock()) == []
+    assert get_injected_names(3, Mock(), d2=Mock(), j=9) == []
+    if func is pos_or_kw:
+        # d1 and d2 passed positionally, no injection
+        assert get_injected_names(3, Mock(), Mock()) == []
+        assert get_injected_names(3, Mock(), Mock(), j=9) == []
+
+
+@pytest.mark.parametrize(
+    "func", [pos_only, pos_only_d1, var_args, var_kwargs, var_args_kwargs]
+)
+def test_not_implemented_parameter_kinds(func):
+    get_injected_names = get_injected_names_factory(func)
+    with pytest.raises(NotImplementedError):
+        get_injected_names(1, Mock(), d2=Mock())

--- a/tests/integrations/base/test_wrap_injection_remove_depends.py
+++ b/tests/integrations/base/test_wrap_injection_remove_depends.py
@@ -1,0 +1,212 @@
+import asyncio
+from collections.abc import Iterable
+from inspect import isasyncgen, iscoroutine, isgenerator
+from unittest.mock import Mock
+
+import pytest
+
+from dishka import FromDishka, make_async_container, make_container
+from dishka.integrations.base import wrap_injection
+from tests.integrations.common import AppMock
+
+
+def raises_multiple_values(obj):
+    with pytest.raises(TypeError, match="multiple values for"):  # noqa: PT012
+        if isgenerator(obj):
+            list(obj)
+        elif callable(obj):
+            obj()
+        else:
+            pytest.fail("Object is neither a generator nor callable")
+
+
+async def raises_multiple_values_async(obj):
+    with pytest.raises(TypeError, match="multiple values for"):  # noqa: PT012
+        if isasyncgen(obj):
+            [x async for x in obj]
+        elif iscoroutine(obj):
+            await obj
+        else:
+            pytest.fail("Object is neither a generator nor callable")
+
+
+def sync_func(i: int, dep: FromDishka[AppMock], j: int = 0):
+    return dep(i, j)
+
+
+def sync_gen(data: Iterable[int], dep: FromDishka[AppMock], j: int = 0):
+    for i in data:
+        yield dep(i, j)
+
+
+async def async_func(i: int, dep: FromDishka[AppMock], j: int = 0):
+    await asyncio.sleep(0)
+    return dep(i, j)
+
+
+async def async_gen(
+    data: Iterable[int],
+    dep: FromDishka[AppMock],
+    j: int = 0,
+):
+    for i in data:
+        await asyncio.sleep(0)
+        yield dep(i, j)
+
+
+@pytest.mark.parametrize("remove_depends", [True, False])
+def test_sync_func(remove_depends, app_provider):
+    container = make_container(app_provider)
+    wrapped_func = wrap_injection(
+        func=sync_func,
+        container_getter=lambda *_: container,
+        remove_depends=remove_depends,
+        is_async=False,
+    )
+
+    wrapped_func(1)
+    app_provider.app_mock.assert_called_with(1, 0)
+    wrapped_func(2, j=3)
+    app_provider.app_mock.assert_called_with(2, 3)
+
+    app_provider.app_mock.reset_mock()
+    new_dep = AppMock(Mock())
+    if remove_depends:
+        raises_multiple_values(lambda: wrapped_func(1, new_dep))
+        raises_multiple_values(lambda: wrapped_func(2, dep=new_dep))
+        raises_multiple_values(lambda: wrapped_func(3, new_dep, 9))
+        raises_multiple_values(lambda: wrapped_func(4, new_dep, j=9))
+        raises_multiple_values(lambda: wrapped_func(5, dep=new_dep, j=9))
+    else:
+        wrapped_func(1, new_dep)
+        new_dep.assert_called_with(1, 0)
+        wrapped_func(2, dep=new_dep)
+        new_dep.assert_called_with(2, 0)
+        wrapped_func(3, new_dep, 9)
+        new_dep.assert_called_with(3, 9)
+        wrapped_func(4, new_dep, j=9)
+        new_dep.assert_called_with(4, 9)
+        wrapped_func(5, dep=new_dep, j=9)
+        new_dep.assert_called_with(5, 9)
+    app_provider.app_mock.assert_not_called()
+
+
+@pytest.mark.parametrize("remove_depends", [True, False])
+def test_sync_gen(remove_depends, app_provider):
+    container = make_container(app_provider)
+    wrapped_func = wrap_injection(
+        func=sync_gen,
+        container_getter=lambda *_: container,
+        remove_depends=remove_depends,
+        is_async=False,
+    )
+
+    list(wrapped_func([1]))
+    app_provider.app_mock.assert_called_with(1, 0)
+    list(wrapped_func([2], j=3))
+    app_provider.app_mock.assert_called_with(2, 3)
+
+    app_provider.app_mock.reset_mock()
+    new_dep = AppMock(Mock())
+    if remove_depends:
+        raises_multiple_values(wrapped_func([1], new_dep))
+        raises_multiple_values(wrapped_func([2], dep=new_dep))
+        raises_multiple_values(wrapped_func([3], new_dep, 9))
+        raises_multiple_values(wrapped_func([4], new_dep, j=9))
+        raises_multiple_values(wrapped_func([5], dep=new_dep, j=9))
+    else:
+        list(wrapped_func([1], new_dep))
+        new_dep.assert_called_with(1, 0)
+        list(wrapped_func([2], dep=new_dep))
+        new_dep.assert_called_with(2, 0)
+        list(wrapped_func([3], new_dep, 9))
+        new_dep.assert_called_with(3, 9)
+        list(wrapped_func([4], new_dep, j=9))
+        new_dep.assert_called_with(4, 9)
+        list(wrapped_func([5], dep=new_dep, j=9))
+        new_dep.assert_called_with(5, 9)
+    app_provider.app_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_container", [True, False])
+@pytest.mark.parametrize("remove_depends", [True, False])
+async def test_async_func(async_container, remove_depends, app_provider):
+    if async_container:
+        container = make_async_container(app_provider)
+    else:
+        container = make_container(app_provider)
+    wrapped_func = wrap_injection(
+        func=async_func,
+        container_getter=lambda *_: container,
+        remove_depends=remove_depends,
+        is_async=async_container,
+    )
+
+    await wrapped_func(1)
+    app_provider.app_mock.assert_called_with(1, 0)
+    await wrapped_func(2, j=3)
+    app_provider.app_mock.assert_called_with(2, 3)
+
+    app_provider.app_mock.reset_mock()
+    new_dep = AppMock(Mock())
+    if remove_depends:
+        await raises_multiple_values_async(wrapped_func(1, new_dep))
+        await raises_multiple_values_async(wrapped_func(2, dep=new_dep))
+        await raises_multiple_values_async(wrapped_func(3, new_dep, 9))
+        await raises_multiple_values_async(wrapped_func(4, new_dep, j=9))
+        await raises_multiple_values_async(wrapped_func(5, dep=new_dep, j=9))
+    else:
+        await wrapped_func(1, new_dep)
+        new_dep.assert_called_with(1, 0)
+        await wrapped_func(2, dep=new_dep)
+        new_dep.assert_called_with(2, 0)
+        await wrapped_func(3, new_dep, 9)
+        new_dep.assert_called_with(3, 9)
+        await wrapped_func(4, new_dep, j=9)
+        new_dep.assert_called_with(4, 9)
+        await wrapped_func(5, dep=new_dep, j=9)
+        new_dep.assert_called_with(5, 9)
+    app_provider.app_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_container", [True, False])
+@pytest.mark.parametrize("remove_depends", [True, False])
+async def test_async_gen(async_container, remove_depends, app_provider):
+    if async_container:
+        container = make_async_container(app_provider)
+    else:
+        container = make_container(app_provider)
+    wrapped_func = wrap_injection(
+        func=async_gen,
+        container_getter=lambda *_: container,
+        remove_depends=remove_depends,
+        is_async=async_container,
+    )
+
+    [item async for item in wrapped_func([1])]
+    app_provider.app_mock.assert_called_with(1, 0)
+    [item async for item in wrapped_func([2], j=3)]
+    app_provider.app_mock.assert_called_with(2, 3)
+
+    app_provider.app_mock.reset_mock()
+    new_dep = AppMock(Mock())
+    if remove_depends:
+        await raises_multiple_values_async(wrapped_func([1], new_dep))
+        await raises_multiple_values_async(wrapped_func([2], dep=new_dep))
+        await raises_multiple_values_async(wrapped_func([3], new_dep, 9))
+        await raises_multiple_values_async(wrapped_func([4], new_dep, j=9))
+        await raises_multiple_values_async(wrapped_func([5], dep=new_dep, j=9))
+    else:
+        [item async for item in wrapped_func([1], new_dep)]
+        new_dep.assert_called_with(1, 0)
+        [item async for item in wrapped_func([2], dep=new_dep)]
+        new_dep.assert_called_with(2, 0)
+        [item async for item in wrapped_func([3], new_dep, 9)]
+        new_dep.assert_called_with(3, 9)
+        [item async for item in wrapped_func([4], new_dep, j=9)]
+        new_dep.assert_called_with(4, 9)
+        [item async for item in wrapped_func([5], dep=new_dep, j=9)]
+        new_dep.assert_called_with(5, 9)
+    app_provider.app_mock.assert_not_called()


### PR DESCRIPTION
`wrap_injection` accepts a `remove_depends` parameter that currently all it does if True is change the annotations and the signature of the decorated function; it has no impact at runtime. Both the default value and all built in integrations use `remove_depends=True`; there's no example (even in tests) with False.

This PR extends (or fixes, depending where you come from) `wrap_injection` to allow the caller of the decorated function pass explicitly dependencies when `remove_depends=False` instead of unconditionally requesting them from the container and injecting them. Explicitly passed dependencies can be passed either by name or positionally if the dependency parameter kind is `POSITIONAL_OR_KEYWORD` (`POSITIONAL_ONLY` dependencies are not currently supported, they could be added separately if needed).

Also added thorough tests and fixed a few typing issues in integrations/base.py.