### PR TITLE
chore: remove `include-package-data`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["setuptools>=66.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-include-package-data = true
-
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
```
[tool.setuptools]
# By default, include-package-data is true in pyproject.toml,
# so you do NOT have to specify this line.
include-package-data = true
```