### PR TITLE
fix(taskiq integration): preserve function type in `inject` decorator

### DIFF
--- a/src/dishka/integrations/taskiq.py
+++ b/src/dishka/integrations/taskiq.py
@@ -9,7 +9,7 @@ import warnings
 from collections.abc import Callable, Generator
 from functools import partial
 from inspect import Parameter
-from typing import Annotated, Any, Final
+from typing import Annotated, Any, Final, TypeVar
 
 from taskiq import (
     AsyncBroker,
@@ -24,6 +24,9 @@ from dishka import AsyncContainer, FromDishka, Provider, Scope, from_context
 from dishka.integrations.base import wrap_injection
 
 CONTAINER_NAME: Final = "dishka_container"
+
+
+_F = TypeVar("_F", bound=Callable[..., Any])
 
 
 class TaskiqProvider(Provider):
@@ -71,10 +74,10 @@ def _get_container(
 
 
 def inject(
-    func: Callable[..., Any] | None = None,
+    func: _F | None = None,
     *,
     patch_module: bool = False,
-) -> Callable[..., Any]:
+) -> _F | Callable[[_F], _F]:
     if func is None:
         return partial(_inject_wrapper, patch_module=patch_module)
 

--- a/src/dishka/integrations/taskiq.py
+++ b/src/dishka/integrations/taskiq.py
@@ -9,7 +9,7 @@ import warnings
 from collections.abc import Callable, Generator
 from functools import partial
 from inspect import Parameter
-from typing import Annotated, Any, Final, TypeVar
+from typing import Annotated, Any, Final, TypeVar, overload
 
 from taskiq import (
     AsyncBroker,
@@ -71,6 +71,18 @@ def _get_container(
     context: Annotated[Context, TaskiqDepends()],
 ) -> Generator[AsyncContainer, None, None]:
     yield context.message.labels[CONTAINER_NAME]
+
+
+@overload
+def inject(
+    func: _F, *, patch_module: bool = False,
+) -> _F: ...
+
+
+@overload
+def inject(
+    func: None = ..., *, patch_module: bool = False,
+) -> Callable[[_F], _F]: ...
 
 
 def inject(


### PR DESCRIPTION
Previous `inject` returned `Callable[..., Any]`, which erased the actual type (e.g. AsyncTaskiqDecoratedTask) and broke autocompletion and type checking.

Replaced it with a generic `_F` and proper return annotation to preserve the original function's type after decoration.