### PR TITLE
fix(litestar): export `DishkaRouter` in `__all__`

### DIFF
--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "DishkaRouter",
     "FromDishka",
     "LitestarProvider",
     "inject",


### PR DESCRIPTION
Added `DishkaRouter` to the `__all__` list in the Litestar integration module.

This ensures `DishkaRouter` is properly exported and available for wildcard imports.

Closes #499.