### PR TITLE
fix `DeprecationWarning`

### DIFF
--- a/src/dishka/provider/make_factory.py
+++ b/src/dishka/provider/make_factory.py
@@ -1,5 +1,4 @@
 import warnings
-from asyncio import iscoroutinefunction
 from collections.abc import (
     AsyncGenerator,
     AsyncIterable,
@@ -16,6 +15,7 @@ from inspect import (
     isasyncgenfunction,
     isbuiltin,
     isclass,
+    iscoroutinefunction,
     isfunction,
     isgeneratorfunction,
     ismethod,


### PR DESCRIPTION
[DeprecationWarning](https://github.com/reagento/dishka/actions/runs/16704940602/job/47281655346#step:8:63): 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead

