### PR TITLE
feat: allow to set scope in wrap_injection

### DIFF
--- a/docs/integrations/adding_new.rst
+++ b/docs/integrations/adding_new.rst
@@ -11,8 +11,22 @@ The main points are:
 2. Find a place to enter and exit request scope and how to pass the container to a handler. Usually, it is entered in a middleware and container is stored in some kind of request context. 
 
    Alternatively, you can use the ``wrap_injection`` function with ``manage_scope=True`` to automate entering and exiting the request scope without relying on middleware. When enabled, ``manage_scope`` ensures that the container passed to ``wrap_injection`` enters and exits the next scope.
+   **Custom Scope Targeting**
 
-   When you use ``manage_scope=True``, you can pass ``provide_context`` function that allows to populate the container context with passed arguments. This is useful when you want to pass the function scoped arguments to other dependencies without relying on middleware.
+   For more complex cases, you can pass a ``scope`` argument to ``wrap_injection`` to specify a custom scope to enter on function call.
+   For example, you can create decorators that target specific scopes in the dependency hierarchy:
+
+   .. code-block:: python
+
+       @inject(scope=Scope.STEP)
+       async def handler(step_dep: StepDep = FromDishka[StepDep]):
+           ...
+
+       @inject(scope=Scope.ACTION)
+       def process_action(action_dep: ActionDep = FromDishka[ActionDep]):
+           ...
+
+   When you use ``manage_scope=True`` or specify a custom ``scope``, you can pass ``provide_context`` function that allows to populate the container context with passed arguments. This is useful when you want to pass the function scoped arguments to other dependencies without relying on middleware.
 3. Configure a decorator. The main option here is to provide a way for retrieving container. Often, need to modify handler signature adding additional parameters. It is also available.
 4. Check if you can apply decorator automatically.
 

--- a/src/dishka/integrations/base.py
+++ b/src/dishka/integrations/base.py
@@ -94,7 +94,7 @@ def _get_auto_injected_async_gen(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, AsyncIterator[T]],
     provide_context: ProvideContext | None = None,
-    **kwargs: Any,
+    scope: Scope | None = None,
 ) -> Callable[P, AsyncIterator[T]]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -155,7 +155,7 @@ def _get_auto_injected_async_func(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Awaitable[T]],
     provide_context: ProvideContext | None = None,
-    **kwargs: Any,
+    scope: Scope | None = None,
 ) -> Callable[P, Awaitable[T]]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -211,7 +211,7 @@ def _get_auto_injected_sync_gen(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Iterator[T]],
     provide_context: ProvideContext | None = None,
-    **kwargs: Any,
+    scope: Scope | None = None,
 ) -> Callable[P, Iterator[T]]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -264,7 +264,7 @@ def _get_auto_injected_sync_func(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, T],
     provide_context: ProvideContext | None = None,
-    **kwargs: Any,
+    scope: Scope | None = None,
 ) -> Callable[P, T]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -289,7 +289,7 @@ def _get_auto_injected_sync_container_async_gen_scoped(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Iterator[T]],
     provide_context: ProvideContext | None = None,
-    **kwargs: Any,
+    scope: Scope | None = None,
 ) -> Callable[P, AsyncIterator[T]]:
     async def auto_injected_generator(
         *args: P.args,
@@ -319,7 +319,7 @@ def _get_auto_injected_sync_container_async_gen(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Iterator[T]],
     provide_context: ProvideContext | None = None,
-    **kwargs: Any,
+    scope: Scope | None = None,
 ) -> Callable[P, AsyncIterator[T]]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -347,7 +347,7 @@ def _get_auto_injected_sync_container_async_func_scoped(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, T],
     provide_context: ProvideContext | None = None,
-    **kwargs: Any,
+    scope: Scope | None = None,
 ) -> Callable[P, T]:
     async def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         for param in additional_params:
@@ -373,7 +373,7 @@ def _get_auto_injected_sync_container_async_func(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, T],
     provide_context: ProvideContext | None = None,
-    **kwargs: Any,
+    scope: Scope | None = None,
 ) -> Callable[P, T]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError

--- a/src/dishka/integrations/base.py
+++ b/src/dishka/integrations/base.py
@@ -35,6 +35,7 @@ from dishka.container import Container
 from dishka.entities.component import DEFAULT_COMPONENT
 from dishka.entities.depends_marker import FromDishka
 from dishka.entities.key import DependencyKey, _FromComponent
+from dishka.entities.scope import Scope
 from dishka.integrations.exceptions import (
     ImproperProvideContextUsageError,
     InvalidInjectedFuncTypeError,
@@ -60,6 +61,7 @@ def _get_auto_injected_async_gen_scoped(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, AsyncIterator[T]],
     provide_context: ProvideContext | None = None,
+    scope: Scope | None = None,
 ) -> Callable[P, AsyncIterator[T]]:
     async def auto_injected_generator(
         *args: P.args,
@@ -72,7 +74,7 @@ def _get_auto_injected_async_gen_scoped(
             {} if provide_context is None else provide_context(args, kwargs)
         )
         container = container_getter(args, kwargs)
-        async with container(additional_context) as container:
+        async with container(additional_context, scope=scope) as container:
             solved = {
                 name: await container.get(
                     dep.type_hint,
@@ -92,6 +94,7 @@ def _get_auto_injected_async_gen(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, AsyncIterator[T]],
     provide_context: ProvideContext | None = None,
+    **kwargs: Any,
 ) -> Callable[P, AsyncIterator[T]]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -123,6 +126,7 @@ def _get_auto_injected_async_func_scoped(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Awaitable[T]],
     provide_context: ProvideContext | None = None,
+    scope: Scope | None = None,
 ) -> Callable[P, Awaitable[T]]:
     async def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         container = container_getter(args, kwargs)
@@ -132,7 +136,7 @@ def _get_auto_injected_async_func_scoped(
         additional_context = (
             {} if provide_context is None else provide_context(args, kwargs)
         )
-        async with container(additional_context) as container:
+        async with container(additional_context, scope=scope) as container:
             solved = {
                 name: await container.get(
                     dep.type_hint,
@@ -151,6 +155,7 @@ def _get_auto_injected_async_func(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Awaitable[T]],
     provide_context: ProvideContext | None = None,
+    **kwargs: Any,
 ) -> Callable[P, Awaitable[T]]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -177,6 +182,7 @@ def _get_auto_injected_sync_gen_scoped(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Iterator[T]],
     provide_context: ProvideContext | None = None,
+    scope: Scope | None = None,
 ) -> Callable[P, Iterator[T]]:
     def auto_injected_generator(
         *args: P.args,
@@ -189,7 +195,7 @@ def _get_auto_injected_sync_gen_scoped(
             {} if provide_context is None else provide_context(args, kwargs)
         )
         container = container_getter(args, kwargs)
-        with container(additional_context) as container:
+        with container(additional_context, scope=scope) as container:
             solved = {
                 name: container.get(dep.type_hint, component=dep.component)
                 for name, dep in dependencies.items()
@@ -205,6 +211,7 @@ def _get_auto_injected_sync_gen(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Iterator[T]],
     provide_context: ProvideContext | None = None,
+    **kwargs: Any,
 ) -> Callable[P, Iterator[T]]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -231,6 +238,7 @@ def _get_auto_injected_sync_func_scoped(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, T],
     provide_context: ProvideContext | None = None,
+    scope: Scope | None = None,
 ) -> Callable[P, T]:
     def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         for param in additional_params:
@@ -240,7 +248,7 @@ def _get_auto_injected_sync_func_scoped(
             {} if provide_context is None else provide_context(args, kwargs)
         )
         container = container_getter(args, kwargs)
-        with container(additional_context) as container:
+        with container(additional_context, scope=scope) as container:
             solved = {
                 name: container.get(dep.type_hint, component=dep.component)
                 for name, dep in dependencies.items()
@@ -256,6 +264,7 @@ def _get_auto_injected_sync_func(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, T],
     provide_context: ProvideContext | None = None,
+    **kwargs: Any,
 ) -> Callable[P, T]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -280,6 +289,7 @@ def _get_auto_injected_sync_container_async_gen_scoped(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Iterator[T]],
     provide_context: ProvideContext | None = None,
+    **kwargs: Any,
 ) -> Callable[P, AsyncIterator[T]]:
     async def auto_injected_generator(
         *args: P.args,
@@ -309,6 +319,7 @@ def _get_auto_injected_sync_container_async_gen(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, Iterator[T]],
     provide_context: ProvideContext | None = None,
+    **kwargs: Any,
 ) -> Callable[P, AsyncIterator[T]]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -336,6 +347,7 @@ def _get_auto_injected_sync_container_async_func_scoped(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, T],
     provide_context: ProvideContext | None = None,
+    **kwargs: Any,
 ) -> Callable[P, T]:
     async def auto_injected_func(*args: P.args, **kwargs: P.kwargs) -> T:
         for param in additional_params:
@@ -361,6 +373,7 @@ def _get_auto_injected_sync_container_async_func(
     dependencies: dict[str, DependencyKey],
     func: Callable[P, T],
     provide_context: ProvideContext | None = None,
+    **kwargs: Any,
 ) -> Callable[P, T]:
     if provide_context is not None:
         raise ImproperProvideContextUsageError
@@ -506,6 +519,7 @@ def wrap_injection(
     parse_dependency: DependencyParser = default_parse_dependency,
     manage_scope: bool = False,
     provide_context: ProvideContext | None = None,
+    scope: Scope | None = None,
 ) -> Callable[P, T]: ...
 
 
@@ -520,6 +534,7 @@ def wrap_injection(
     parse_dependency: DependencyParser = default_parse_dependency,
     manage_scope: bool = False,
     provide_context: ProvideContext | None = None,
+    scope: Scope | None = None,
 ) -> Callable[P, T]: ...
 
 
@@ -532,6 +547,7 @@ def wrap_injection(
     additional_params: Sequence[Parameter] = (),
     parse_dependency: DependencyParser = default_parse_dependency,
     manage_scope: bool = False,
+    scope: Scope | None = None,
     provide_context: ProvideContext | None = None,
 ) -> Callable[P, T]:
     hints = get_type_hints(func, include_extras=True)
@@ -593,7 +609,7 @@ def wrap_injection(
 
     injected_func_type = InjectedFuncType(
         is_async_container=is_async,
-        manage_scope=manage_scope,
+        manage_scope=manage_scope or bool(scope),
         func_type=get_func_type(func),
     )
     get_auto_injected_func = _GET_AUTO_INJECTED_FUNC_DICT[injected_func_type]
@@ -604,6 +620,7 @@ def wrap_injection(
         dependencies=dependencies,
         additional_params=additional_params,
         container_getter=container_getter,
+        scope=scope,
     )
 
     auto_injected_func.__dishka_orig_func__ = func

--- a/tests/integrations/base/test_wrap_injection_custom_scope.py
+++ b/tests/integrations/base/test_wrap_injection_custom_scope.py
@@ -1,0 +1,89 @@
+from collections.abc import AsyncIterator, Callable, Iterator
+from inspect import isasyncgenfunction, isgeneratorfunction
+
+import pytest
+
+from dishka import Container, Scope
+from dishka.async_container import AsyncContainer
+from dishka.entities.depends_marker import FromDishka
+from dishka.integrations.base import wrap_injection
+from tests.integrations.common import REQUEST_DEP_VALUE, StepDep
+
+
+def generate_str(step: StepDep, prefix: int | None = None) -> str:
+    s = str(step)
+    if prefix is not None:
+        s = f"{prefix}. {s}"
+    return s
+
+
+def sync_func(step: FromDishka[StepDep]) -> str:
+    return generate_str(step)
+
+
+def sync_gen(data: list[int], step: FromDishka[StepDep]) -> Iterator[str]:
+    for i in data:
+        yield generate_str(step, i)
+
+
+async def async_func(step: FromDishka[StepDep]) -> str:
+    return generate_str(step)
+
+
+async def async_gen(
+    data: list[int],
+    step: FromDishka[StepDep],
+) -> AsyncIterator[str]:
+    for i in data:
+        yield generate_str(step, i)
+
+
+@pytest.mark.parametrize("func", [sync_func, sync_gen])
+@pytest.mark.parametrize("manage_scope", [False, True])
+def test_sync_custom_scope(
+    func: Callable, manage_scope: bool, container: Container
+) -> None:
+    wrapped_func = wrap_injection(
+        func=func,
+        container_getter=lambda *_: container,
+        is_async=False,
+        manage_scope=manage_scope,
+        scope=Scope.STEP,
+    )
+
+    if isgeneratorfunction(func):
+        result = list(wrapped_func([1, 2]))
+        assert result == [
+            generate_str(StepDep(f"step for {REQUEST_DEP_VALUE}"), i)
+            for i in [1, 2]
+        ]
+    else:
+        result = wrapped_func()
+        assert result == generate_str(StepDep(f"step for {REQUEST_DEP_VALUE}"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("func", [async_func, async_gen])
+@pytest.mark.parametrize("manage_scope", [False, True])
+async def test_async_custom_scope(
+    func: Callable,
+    manage_scope: bool,
+    async_container: AsyncContainer,
+) -> None:
+    wrapped_func = wrap_injection(
+        func=func,
+        container_getter=lambda *_: async_container,
+        is_async=True,
+        manage_scope=manage_scope,
+        scope=Scope.STEP,
+    )
+
+    if isasyncgenfunction(func):
+        result = [item async for item in wrapped_func([1, 2])]
+        assert result == [
+            generate_str(StepDep(f"step for {REQUEST_DEP_VALUE}"), i)
+            for i in [1, 2]
+        ]
+    else:
+        result = await wrapped_func()
+        assert result == generate_str(StepDep(f"step for {REQUEST_DEP_VALUE}"))

--- a/tests/integrations/base/test_wrap_injection_custom_scope.py
+++ b/tests/integrations/base/test_wrap_injection_custom_scope.py
@@ -41,7 +41,10 @@ async def async_gen(
 @pytest.mark.parametrize("func", [sync_func, sync_gen])
 @pytest.mark.parametrize("manage_scope", [False, True])
 def test_sync_custom_scope(
-    func: Callable, manage_scope: bool, container: Container
+    func: Callable,
+    *,
+    manage_scope: bool,
+    container: Container,
 ) -> None:
     wrapped_func = wrap_injection(
         func=func,
@@ -67,6 +70,7 @@ def test_sync_custom_scope(
 @pytest.mark.parametrize("manage_scope", [False, True])
 async def test_async_custom_scope(
     func: Callable,
+    *,
     manage_scope: bool,
     async_container: AsyncContainer,
 ) -> None:

--- a/tests/integrations/base/test_wrap_injection_provide_context.py
+++ b/tests/integrations/base/test_wrap_injection_provide_context.py
@@ -69,10 +69,13 @@ def provide_context(
 
 @pytest.mark.parametrize("func", [sync_func, sync_gen])
 @pytest.mark.parametrize(
-    "scope_tuple", [(True, None), (False, Scope.STEP), (True, Scope.STEP)]
+    "scope_tuple",
+    [(True, None), (False, Scope.STEP), (True, Scope.STEP)],
 )
 def test_sync_provide_context(
-    func: Callable, scope_tuple: tuple[bool, Scope], container: Container
+    func: Callable,
+    scope_tuple: tuple[bool, Scope],
+    container: Container,
 ) -> None:
     manage_scope, scope = scope_tuple
     wrapped_func = wrap_injection(
@@ -107,7 +110,8 @@ def test_invalid_provide_context(func: Callable, container: Container) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("func", [async_func, async_gen])
 @pytest.mark.parametrize(
-    "scope_tuple", [(True, None), (False, Scope.STEP), (True, Scope.STEP)]
+    "scope_tuple",
+    [(True, None), (False, Scope.STEP), (True, Scope.STEP)],
 )
 async def test_async_provide_context(
     func: Callable,

--- a/tests/integrations/base/test_wrap_injection_provide_context.py
+++ b/tests/integrations/base/test_wrap_injection_provide_context.py
@@ -7,6 +7,7 @@ import pytest
 from dishka.async_container import AsyncContainer
 from dishka.container import Container
 from dishka.entities.depends_marker import FromDishka
+from dishka.entities.scope import Scope
 from dishka.integrations.base import wrap_injection
 from dishka.integrations.exceptions import ImproperProvideContextUsageError
 from tests.integrations.common import ContextDep, UserDep
@@ -67,12 +68,19 @@ def provide_context(
 
 
 @pytest.mark.parametrize("func", [sync_func, sync_gen])
-def test_sync_provide_context(func: Callable, container: Container) -> None:
+@pytest.mark.parametrize(
+    "scope_tuple", [(True, None), (False, Scope.STEP), (True, Scope.STEP)]
+)
+def test_sync_provide_context(
+    func: Callable, scope_tuple: tuple[bool, Scope], container: Container
+) -> None:
+    manage_scope, scope = scope_tuple
     wrapped_func = wrap_injection(
         func=func,
         container_getter=lambda *_: container,
         is_async=False,
-        manage_scope=True,
+        manage_scope=manage_scope,
+        scope=scope,
         provide_context=provide_context,
     )
 
@@ -98,15 +106,21 @@ def test_invalid_provide_context(func: Callable, container: Container) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("func", [async_func, async_gen])
+@pytest.mark.parametrize(
+    "scope_tuple", [(True, None), (False, Scope.STEP), (True, Scope.STEP)]
+)
 async def test_async_provide_context(
     func: Callable,
+    scope_tuple: tuple[bool, Scope],
     async_container: AsyncContainer,
 ) -> None:
+    manage_scope, scope = scope_tuple
     wrapped_func = wrap_injection(
         func=func,
         container_getter=lambda *_: async_container,
         is_async=True,
-        manage_scope=True,
+        manage_scope=manage_scope,
+        scope=scope,
         provide_context=provide_context,
     )
 

--- a/tests/integrations/common.py
+++ b/tests/integrations/common.py
@@ -7,6 +7,7 @@ from dishka.entities.depends_marker import FromDishka
 
 ContextDep = NewType("ContextDep", str)
 UserDep = NewType("UserDep", str)
+StepDep = NewType("StepDep", str)
 
 AppDep = NewType("AppDep", str)
 APP_DEP_VALUE = "APP"
@@ -59,6 +60,10 @@ class AppProvider(Provider):
     @provide(scope=Scope.APP)
     def app_mock(self) -> AppMock:
         return self.app_mock
+
+    @provide(scope=Scope.STEP)
+    def step(self, request: FromDishka[RequestDep]) -> StepDep:
+        return StepDep(f"step for {request}")
 
 
 class WebSocketAppProvider(Provider):


### PR DESCRIPTION
## Motivation

I'd like to be able to pass custom scope when I wrap my functions with inject like
```python
@inject(scope=Scope.STEP)
async def my_function(...) -> None:
    ...
```

## Description

This PR contains an extension for `wrap_injection` function that allows to pass scope the container should enter in

## Notes

- if `manage_scope=False` and `scope` is set - the container would be scoped anyway
- `scope` has higher priority than `manage_scope=True` -> container enters pointed scope
- scope should be lower than current container scope 
  @ApostolFet @Tishka17 I guess I need to address this case, shall we raise an error during runtime? Or the container throws it by default
- shall I add `@inject` decorator example into the doc?
  ```python
    def inject(
      func: Callable[P, T] | None = None,
      *,
      scope: Scope | None = None
  ):
      """
      Decorator for dependency injection that can be used with or without arguments.

      Usage:
          @inject
          def handler(dep: Dep = FromDishka[Dep]):
              ...

          @inject(scope=Scope.STEP)
          def handler(step_dep: StepDep = FromDishka[StepDep]):
              ...
      """
      def decorator(f: Callable[P, T]) -> Callable[P, T]:
          return wrap_injection(
              func=f,
              container_getter=get_container,  # Your container getter function
              is_async=True,
              scope=scope,
          )

      if func is None:
          # Called with arguments: @inject(scope=Scope.STEP)
          return decorator
      else:
          # Called without arguments: @inject
          return decorator(func)
   ```