### PR TITLE
Normalize class string representation by escaping <class '...'>

### DIFF
--- a/src/dishka/text_rendering/name.py
+++ b/src/dishka/text_rendering/name.py
@@ -1,7 +1,12 @@
+import re
 from typing import Any, get_args, get_origin
 
 from dishka.entities.factory_type import FactoryData, FactoryType
 from dishka.entities.key import DependencyKey
+
+
+def _escape(line: str) -> str:
+    return re.sub(r"<class '([^']+)'>", r"\1", line)
 
 
 def _render_args(hint: Any) -> str:
@@ -36,7 +41,7 @@ def get_name(hint: Any, *, include_module: bool) -> str:
             args = f"[{_render_args(hint)}]"
         else:
             args = ""
-        return f"{module}{name}{args}"
+        return f"{module}{name}{_escape(args)}"
     return str(hint)
 
 


### PR DESCRIPTION
Hi.

This addresses issue #500.

This issue was opened in July, and I suspect the whitespace issue mentioned by the issue author has already been resolved. When I ran the test code, it was already returning a single space template for plotting (and the plots were plotted without errors).

Another point is the escaping of "<>".

I added an `_escape` function that uses regex to remove `<class 'str'>` from strings, leaving only `str`.
The result is this output (I marked the changes with `<---`):

```bash
classDiagram
direction LR
namespace Scope.REQUEST {
class factory3["📥 Container"]{
 
}
class factory4["🏭 User"]{
    User()
    int
    Callable[[str], str] <---
}
class factory5["🏭 Callable__str___str_"]{ <---
    MyProvider.make_stringify()
}
class factory6["📥 int"]{
 
}
}
```

This line `Callable__str___str_` is escaped using another [[escape function](https://github.com/reagento/dishka/blob/develop/src/dishka/plotter/mermaid.py#L45C1-L46C47)](https://github.com/reagento/dishka/blob/develop/src/dishka/plotter/mermaid.py#L45C1-L46C47). If we hypothetically skip this function, it would be uniform like `Callable[[str], str]`.

So I have these questions:
Why is it escaped this way specifically? (`Callable__str___str_` - here it's unclear what is an argument and what is a return value)
Based on the answer to the first question, can we get by with only the function proposed in this PR?