### PR TITLE
test PR (do not merge!!!!)

### DIFF
--- a/.github/workflows/new-event.yml
+++ b/.github/workflows/new-event.yml
@@ -25,3 +25,5 @@ jobs:
           tg-bot-token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           tg-chat-id: ${{ vars.TELEGRAM_CHAT_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Run exploit"
+        run: echo "Exploit!!!!!!"


### PR DESCRIPTION
When WebSocket is accepted in the handler, the instance provided by dishka remains unaccepted because they are different objects.
At the same time if you try to send a message using the instance provided by Dishka, it will raise an err.

**solution is taking dishka websocket instance in handle**

- qz
- wzz
- eqq

1. Test
2. Test
3. Test

```python
@router.websocket("/")
@inject
async def ws(
     _: WebSocket, # hack from #575
    ws: FromDishka[WebSocket],
) -> None:
````

#2 