### PR TITLE
Update test requirements after 3.14 release

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -61,6 +61,7 @@ INTEGRATIONS = [
     IntegrationEnv("flask", "latest"),
     IntegrationEnv("grpcio", "1641", python_version_less(3, 13)),
     IntegrationEnv("grpcio", "1680", python_version_less(3, 14)),
+    IntegrationEnv("grpcio", "1751"),
     IntegrationEnv("grpcio", "latest"),
     IntegrationEnv("litestar", "232"),
     IntegrationEnv("litestar", "latest"),

--- a/requirements/fastapi-0109.txt
+++ b/requirements/fastapi-0109.txt
@@ -1,3 +1,2 @@
 -r asgi.txt
 fastapi==0.109.0
-pydantic>=2.12.0a1

--- a/requirements/faststream-060.txt
+++ b/requirements/faststream-060.txt
@@ -2,4 +2,3 @@
 
 faststream[nats]==0.6.0rc0
 fast-depends==3.0.0a12
-pydantic>=2.12.0a1

--- a/requirements/grpcio-1751.txt
+++ b/requirements/grpcio-1751.txt
@@ -1,0 +1,4 @@
+-r test.txt
+grpcio==1.75.1
+grpcio-tools==1.75.1
+grpcio-testing==1.75.1

--- a/requirements/taskiq-0110.txt
+++ b/requirements/taskiq-0110.txt
@@ -1,3 +1,2 @@
 -r test.txt
 taskiq==0.11.0
-pydantic>=2.12.0a1

--- a/requirements/taskiq-latest.txt
+++ b/requirements/taskiq-latest.txt
@@ -1,3 +1,2 @@
 -r test.txt
 taskiq
-pydantic>=2.12.0a1


### PR DESCRIPTION
Part of https://github.com/reagento/dishka/issues/541

[`Pydantic`](https://pypi.org/project/pydantic/2.12.0/) has released a stable version with support python 3.14.