### PR TITLE
override default `_version.py` using `version_file_template`

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,7 +8,6 @@ include = [
 ]
 exclude = [
     "src/dishka/_adaptix/**",
-    "src/dishka/_version.py",
 ]
 
 lint.select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 
-[tool.setuptools_scm]
-version_file = "src/dishka/_version.py"
-
 [project]
 name = "dishka"
 dynamic = ["version"]
@@ -42,3 +39,21 @@ dependencies = [
 "Homepage" = "https://github.com/reagento/dishka"
 "Documentation" = "https://dishka.readthedocs.io/en/stable/"
 "Bug Tracker" = "https://github.com/reagento/dishka/issues"
+
+[tool.setuptools_scm]
+version_file = "src/dishka/_version.py"
+version_file_template = """\
+# This file auto generated!
+# DO NOT EDIT MANUALLY!
+
+version: str = "{version}"
+__version__: str = "{version}"
+
+commit_hash: str = "{scm_version.node}"
+version_timestamp: str = "{scm_version.time}"
+
+tag: str = "{scm_version.tag}"
+branch: str = "{scm_version.branch}"
+commit_date: str = "{scm_version.node_date}"
+commit_count_since_tag: int = {scm_version.distance}
+"""


### PR DESCRIPTION
`_version.py`:
```py
# This file auto generated!
# DO NOT EDIT MANUALLY!

version: str = "1.6.1.dev225+g107646f0b.d20251031"
__version__: str = "1.6.1.dev225+g107646f0b.d20251031"

commit_hash: str = "g107646f0b02f31222b7742a4729bd1a79f11287e"
version_timestamp: str = "2025-10-31 15:18:35.292502+00:00"

tag: str = "1.6.0"
branch: str = "develop"
commit_date: str = "2025-10-25"
commit_count_since_tag: int = 225
```