### PR TITLE
feat: add when= parameter to Provider class

### DIFF
--- a/docs/advanced/when.rst
+++ b/docs/advanced/when.rst
@@ -101,6 +101,48 @@ Markers support simple combination logic when used in ``when=`` using ``|`` (or)
             return TestCacheImpl()
 
 
+Provider-level activation
+-------------------------
+
+You can set ``when=`` on the entire provider to apply a condition to all factories, aliases, and decorators within it. This reduces boilerplate when all dependencies in a provider share the same activation condition.
+
+.. code-block:: python
+
+    from dishka import Marker, Provider, Scope, provide
+
+    class DebugProvider(Provider):
+        when = Marker("debug")
+        scope = Scope.APP
+
+        @provide
+        def debug_cache(self) -> Cache:
+            return DebugCacheImpl()
+
+        @provide
+        def debug_logger(self) -> Logger:
+            return VerboseLogger()
+
+The provider's ``when`` can also be set via constructor:
+
+.. code-block:: python
+
+    provider = DebugProvider(when=Marker("debug"))
+
+When both provider and individual source have ``when=``, conditions are combined with AND logic:
+
+.. code-block:: python
+
+    class FeatureProvider(Provider):
+        when = Marker("prod")  # prerequisite
+        scope = Scope.APP
+
+        @provide(when=Has(RedisConfig))  # additional condition
+        def redis_cache(self, config: RedisConfig) -> Cache:
+            return RedisCache(config)
+        # Effective: Marker("prod") & Has(RedisConfig)
+
+The provider's ``when`` acts as a prerequisite; individual sources add further constraints. If a factory shouldn't inherit the provider's condition, move it to a different provider.
+
 Checking graph elements
 ---------------------------------------
 

--- a/src/dishka/dependency_source/alias.py
+++ b/src/dishka/dependency_source/alias.py
@@ -3,7 +3,7 @@ from typing import Any
 from dishka.entities.component import Component
 from dishka.entities.factory_type import FactoryType
 from dishka.entities.key import DependencyKey
-from dishka.entities.marker import BaseMarker
+from dishka.entities.marker import BaseMarker, combine_when
 from dishka.entities.scope import BaseScope
 from .factory import Factory
 
@@ -54,9 +54,23 @@ class Alias:
             cache=self.cache,
             when_override=self.when_override,
             when_active=self.when_active,
-            when_component=self.when_component,
+            when_component=(
+                component
+                if self.when_component is None
+                else self.when_component
+            ),
             when_dependencies={},
         )
 
     def __get__(self, instance: Any, owner: Any) -> "Alias":
-        return self
+        provider_when = getattr(instance, "when", None)
+        if provider_when is None:
+            return self
+        return Alias(
+            source=self.source,
+            provides=self.provides,
+            cache=self.cache,
+            when_active=combine_when(provider_when, self.when_active),
+            when_override=combine_when(provider_when, self.when_override),
+            when_component=self.when_component,
+        )

--- a/src/dishka/dependency_source/decorator.py
+++ b/src/dishka/dependency_source/decorator.py
@@ -2,7 +2,7 @@ from typing import Any, TypeVar, get_args, get_origin
 
 from dishka.entities.component import Component
 from dishka.entities.key import DependencyKey
-from dishka.entities.marker import BaseMarker, BoolMarker
+from dishka.entities.marker import BaseMarker, BoolMarker, combine_when
 from dishka.entities.scope import BaseScope
 from .factory import Factory
 from .type_match import get_typevar_replacement, is_broader_or_same_type
@@ -99,8 +99,10 @@ class Decorator:
         return old_key
 
     def __get__(self, instance: Any, owner: Any) -> "Decorator":
+        provider_when = getattr(instance, "when", None)
+        combined_when = combine_when(provider_when, self.when)
         return Decorator(
             self.factory.__get__(instance, owner),
             scope=self.scope,
-            when=self.when,
+            when=combined_when,
         )

--- a/src/dishka/dependency_source/factory.py
+++ b/src/dishka/dependency_source/factory.py
@@ -9,7 +9,7 @@ from typing import Any
 from dishka.entities.component import Component
 from dishka.entities.factory_type import FactoryData, FactoryType
 from dishka.entities.key import DependencyKey
-from dishka.entities.marker import BaseMarker
+from dishka.entities.marker import BaseMarker, combine_when
 from dishka.entities.scope import BaseScope
 
 
@@ -76,6 +76,9 @@ class Factory(FactoryData):
         scope = self.scope or instance.scope
         if instance is None:
             return self
+        provider_when = getattr(instance, "when", None)
+        when_active = combine_when(provider_when, self.when_active)
+        when_override = combine_when(provider_when, self.when_override)
         if self.is_to_bind:
             source = self.source.__get__(instance, owner)
             dependencies = self.dependencies[1:]
@@ -91,8 +94,8 @@ class Factory(FactoryData):
             type_=self.type,
             is_to_bind=False,
             cache=self.cache,
-            when_override=self.when_override,
-            when_active=self.when_active,
+            when_override=when_override,
+            when_active=when_active,
             when_component=self.when_component,
             when_dependencies=self.when_dependencies,
         )

--- a/src/dishka/entities/marker.py
+++ b/src/dishka/entities/marker.py
@@ -125,6 +125,17 @@ def or_markers(*markers: BaseMarker | None) -> BaseMarker | None:
     return current_marker
 
 
+def combine_when(
+    provider_when: BaseMarker | None,
+    source_when: BaseMarker | None,
+) -> BaseMarker | None:
+    if provider_when is None:
+        return source_when
+    if source_when is None:
+        return provider_when
+    return provider_when & source_when
+
+
 @dataclass(frozen=True, slots=True)
 class Has(Marker):
     """

--- a/src/dishka/provider/provider.py
+++ b/src/dishka/provider/provider.py
@@ -50,14 +50,17 @@ class Provider(BaseProvider):
     """
     scope: BaseScope | None = None
     component: Component = DEFAULT_COMPONENT
+    when: BaseMarker | None = None
 
     def __init__(
             self,
             scope: BaseScope | None = None,
             component: Component | None = None,
+            when: BaseMarker | None = None,
     ):
         super().__init__(component)
         self.scope = scope or self.scope
+        self.when = when or self.when
         self._init_dependency_sources()
 
     def _init_dependency_sources(self) -> None:

--- a/tests/unit/container/when/test_provider_when.py
+++ b/tests/unit/container/when/test_provider_when.py
@@ -1,0 +1,343 @@
+import pytest
+
+from dishka import (
+    Marker,
+    Provider,
+    Scope,
+    alias,
+    decorate,
+    make_container,
+    provide,
+)
+
+
+@pytest.mark.parametrize(
+    ("provider_active", "expected"),
+    [(True, "conditional"), (False, "default")],
+)
+def test_factory_inherits_provider_when(provider_active, expected):
+    class DefaultProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_value(self) -> str:
+            return "default"
+
+    class ConditionalProvider(Provider):
+        scope = Scope.APP
+        when = Marker("provider")
+
+        @provide
+        def get_value(self) -> str:
+            return "conditional"
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: provider_active, Marker("provider"))
+
+    container = make_container(
+        DefaultProvider(), ConditionalProvider(), activator,
+    )
+    assert container.get(str) == expected
+
+
+@pytest.mark.parametrize(
+    ("provider_active", "factory_active", "expected"),
+    [
+        (True, True, "both_active"),
+        (True, False, "default"),
+        (False, True, "default"),
+        (False, False, "default"),
+    ],
+)
+def test_factory_combines_when_with_provider(
+    provider_active, factory_active, expected,
+):
+    class DefaultProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_value(self) -> str:
+            return "default"
+
+    class ConditionalProvider(Provider):
+        scope = Scope.APP
+        when = Marker("provider")
+
+        @provide(when=Marker("factory"))
+        def get_value(self) -> str:
+            return "both_active"
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: provider_active, Marker("provider"))
+    activator.activate(lambda: factory_active, Marker("factory"))
+
+    container = make_container(
+        DefaultProvider(), ConditionalProvider(), activator,
+    )
+    assert container.get(str) == expected
+
+
+@pytest.mark.parametrize(
+    ("factory_active", "expected"),
+    [(True, "factory_when"), (False, "default")],
+)
+def test_factory_when_without_provider_when(factory_active, expected):
+    class MyProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_default(self) -> str:
+            return "default"
+
+        @provide(when=Marker("factory"))
+        def get_conditional(self) -> str:
+            return "factory_when"
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: factory_active, Marker("factory"))
+
+    container = make_container(MyProvider(), activator)
+    assert container.get(str) == expected
+
+
+@pytest.mark.parametrize(
+    ("provider_active", "expected"),
+    [(True, "decorated:base"), (False, "base")],
+)
+def test_decorator_inherits_provider_when(provider_active, expected):
+    class BaseProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_value(self) -> str:
+            return "base"
+
+    class DecoratorProvider(Provider):
+        scope = Scope.APP
+        when = Marker("provider")
+
+        @decorate
+        def wrap(self, value: str) -> str:
+            return f"decorated:{value}"
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: provider_active, Marker("provider"))
+
+    container = make_container(
+        BaseProvider(), DecoratorProvider(), activator,
+    )
+    assert container.get(str) == expected
+
+
+@pytest.mark.parametrize(
+    ("provider_active", "decorator_active", "expected"),
+    [
+        (True, True, "decorated:base"),
+        (True, False, "base"),
+        (False, True, "base"),
+        (False, False, "base"),
+    ],
+)
+def test_decorator_combines_when_with_provider(
+    provider_active, decorator_active, expected,
+):
+    class BaseProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_value(self) -> str:
+            return "base"
+
+    class DecoratorProvider(Provider):
+        scope = Scope.APP
+        when = Marker("provider")
+
+        @decorate(when=Marker("decorator"))
+        def wrap(self, value: str) -> str:
+            return f"decorated:{value}"
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: provider_active, Marker("provider"))
+    activator.activate(lambda: decorator_active, Marker("decorator"))
+
+    container = make_container(
+        BaseProvider(), DecoratorProvider(), activator,
+    )
+    assert container.get(str) == expected
+
+
+@pytest.mark.parametrize(
+    ("decorator_active", "expected"),
+    [(True, "decorated:base"), (False, "base")],
+)
+def test_decorator_when_without_provider_when(decorator_active, expected):
+    class MyProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_value(self) -> str:
+            return "base"
+
+        @decorate(when=Marker("decorator"))
+        def wrap(self, value: str) -> str:
+            return f"decorated:{value}"
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: decorator_active, Marker("decorator"))
+
+    container = make_container(MyProvider(), activator)
+    assert container.get(str) == expected
+
+
+@pytest.mark.parametrize(
+    ("marker_a_active", "marker_b_active", "expected"),
+    [
+        (True, True, "conditional"),
+        (True, False, "conditional"),
+        (False, True, "conditional"),
+        (False, False, "default"),
+    ],
+)
+def test_provider_when_or_expression(
+    marker_a_active, marker_b_active, expected,
+):
+    class DefaultProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_value(self) -> str:
+            return "default"
+
+    class ConditionalProvider(Provider):
+        scope = Scope.APP
+        when = Marker("a") | Marker("b")
+
+        @provide
+        def get_value(self) -> str:
+            return "conditional"
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: marker_a_active, Marker("a"))
+    activator.activate(lambda: marker_b_active, Marker("b"))
+
+    container = make_container(
+        DefaultProvider(), ConditionalProvider(), activator,
+    )
+    assert container.get(str) == expected
+
+
+@pytest.mark.parametrize(
+    ("marker_a_active", "marker_b_active", "expected"),
+    [
+        (True, True, "conditional"),
+        (True, False, "default"),
+        (False, True, "default"),
+        (False, False, "default"),
+    ],
+)
+def test_provider_when_and_expression(
+    marker_a_active, marker_b_active, expected,
+):
+    class DefaultProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_value(self) -> str:
+            return "default"
+
+    class ConditionalProvider(Provider):
+        scope = Scope.APP
+        when = Marker("a") & Marker("b")
+
+        @provide
+        def get_value(self) -> str:
+            return "conditional"
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: marker_a_active, Marker("a"))
+    activator.activate(lambda: marker_b_active, Marker("b"))
+
+    container = make_container(
+        DefaultProvider(), ConditionalProvider(), activator,
+    )
+    assert container.get(str) == expected
+
+
+@pytest.mark.parametrize(
+    ("provider_active", "expected"),
+    [(True, 1.0), (False, 0.0)],
+)
+def test_alias_inherits_provider_when(provider_active, expected):
+    class DefaultProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_int(self) -> int:
+            return 0
+
+        @provide
+        def get_float(self) -> float:
+            return 0.0
+
+    class ConditionalProvider(Provider):
+        scope = Scope.APP
+        when = Marker("provider")
+
+        @provide
+        def get_int(self) -> int:
+            return 1
+
+        float_alias = alias(source=int, provides=float)
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: provider_active, Marker("provider"))
+
+    container = make_container(
+        DefaultProvider(), ConditionalProvider(), activator,
+    )
+    assert container.get(float) == expected
+
+
+@pytest.mark.parametrize(
+    ("provider_active", "alias_active", "expected"),
+    [
+        (True, True, 1.0),
+        (True, False, 0.0),
+        (False, True, 0.0),
+        (False, False, 0.0),
+    ],
+)
+def test_alias_combines_when_with_provider(
+    provider_active, alias_active, expected,
+):
+    class DefaultProvider(Provider):
+        scope = Scope.APP
+
+        @provide
+        def get_int(self) -> int:
+            return 0
+
+        @provide
+        def get_float(self) -> float:
+            return 0.0
+
+    class ConditionalProvider(Provider):
+        scope = Scope.APP
+        when = Marker("provider")
+
+        @provide
+        def get_int(self) -> int:
+            return 1
+
+        float_alias = alias(
+            source=int, provides=float, when=Marker("alias"),
+        )
+
+    activator = Provider(scope=Scope.APP)
+    activator.activate(lambda: provider_active, Marker("provider"))
+    activator.activate(lambda: alias_active, Marker("alias"))
+
+    container = make_container(
+        DefaultProvider(), ConditionalProvider(), activator,
+    )
+    assert container.get(float) == expected

--- a/tests/unit/test_marker.py
+++ b/tests/unit/test_marker.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dishka import Has, Marker
-from dishka.entities.marker import BoolMarker
+from dishka.entities.marker import BoolMarker, combine_when
 
 
 class Child(Marker):
@@ -64,3 +64,17 @@ def test_bool():
 )
 def test_repr(marker, repr_value):
     assert repr(marker) == repr_value
+
+
+@pytest.mark.parametrize(
+    ("provider_when", "source_when", "expected"),
+    [
+        (None, None, None),
+        (Marker("a"), None, Marker("a")),
+        (None, Marker("b"), Marker("b")),
+        (Marker("a"), Marker("b"), Marker("a") & Marker("b")),
+    ],
+)
+def test_combine_when(provider_when, source_when, expected):
+    result = combine_when(provider_when, source_when)
+    assert result == expected

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -23,7 +23,14 @@ from typing import (
 
 import pytest
 
-from dishka import Provider, Scope, alias, decorate, make_container, provide
+from dishka import (
+    Provider,
+    Scope,
+    alias,
+    decorate,
+    make_container,
+    provide,
+)
 from dishka._adaptix.feature_requirement import HAS_TV_DEFAULT
 from dishka.entities.factory_type import FactoryType
 from dishka.entities.key import (


### PR DESCRIPTION
Adds `when=` to Provider, similar to how `scope` and `component` work.

```python
class DebugProvider(Provider):
    when = Marker("debug")
    scope = Scope.APP

    @provide
    def cache(self) -> Cache: ...
```

When both provider and source have `when=`, they're AND-combined.

Closes #644