### PR TITLE
fix: resolve `RecursionError` when activator is in same provider as its marker (#689)

### DIFF
--- a/src/dishka/dependency_source/activator.py
+++ b/src/dishka/dependency_source/activator.py
@@ -21,8 +21,13 @@ class Activator:
         self.marker_type = marker_type
 
     def __get__(self, instance: Any, owner: Any) -> "Activator":
+        factory = self.factory.__get__(instance, owner)
+        factory = factory.replace(
+            when_active=None,
+            when_override=None,
+        )
         return Activator(
-            factory=self.factory.__get__(instance, owner),
+            factory=factory,
             marker=self.marker,
             marker_type=self.marker_type,
         )

--- a/tests/unit/container/when/test_provider_when.py
+++ b/tests/unit/container/when/test_provider_when.py
@@ -4,6 +4,7 @@ from dishka import (
     Marker,
     Provider,
     Scope,
+    activate,
     alias,
     decorate,
     make_container,
@@ -341,3 +342,20 @@ def test_alias_combines_when_with_provider(
         DefaultProvider(), ConditionalProvider(), activator,
     )
     assert container.get(float) == expected
+
+
+def test_activate_in_provider_with_when_no_recursion():
+    class TestProvider(Provider):
+        when = Marker("debug")
+        scope = Scope.APP
+
+        @activate(Marker("debug"))
+        def is_debug(self) -> bool:
+            return True
+
+        @provide()
+        def provide_int(self) -> int:
+            return 1
+
+    container = make_container(TestProvider())
+    assert container.get(int) == 1


### PR DESCRIPTION
Fixes #689

- Activators should not inherit `when_active`/`when_override` conditions from the provider's `when`, as they are the source of marker activation, not consumers, so we reset both to `None` in `Activator.__get__()` after `Factory.__get__()` applies the provider-level `when`.
- Added regression test based on MRE from #689
