### PR TITLE
Update jobify GitHub link in documentation

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -23,7 +23,7 @@ Some of the integrations are supported by a community, refer to their documentat
    flask
    flet <https://github.com/C3EQUALZz/dishka-flet>
    grpcio
-   jobify <https://github.com/C3EQUALZz/dishka-jobify>
+   jobify <https://github.com/Jobify-Community/dishka-jobify>
    litestar
    Pyramid <https://github.com/WorkHardes/dishka-pyramid>
    RQ <https://github.com/prepin/dishka-rq>

--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -69,7 +69,7 @@ Some of the integrations are supported by a community, refer to their documentat
      -
    * - `Pyramid <https://github.com/WorkHardes/dishka-pyramid>`_ (:abbr:`com (Community support)`)
      -
-     - `Jobify <https://github.com/C3EQUALZz/dishka-jobify>`_ (:abbr:`com (Community support)`)
+     - `Jobify <https://github.com/Jobify-Community/dishka-jobify>`_ (:abbr:`com (Community support)`)
      -
    * -  :ref:`Sanic`
      -


### PR DESCRIPTION
For jobify framework we created organisation on Github: https://github.com/Jobify-Community/ 

Repository was migrated to organisation