### PR TITLE
feat(litestar): add support for guards with ASGIConnection parameter

### DIFF
--- a/docs/integrations/litestar.rst
+++ b/docs/integrations/litestar.rst
@@ -126,3 +126,22 @@ or with class-based handler:
             async with container() as request_container:
                 b = await request_container.get(B)  # object with Scope.REQUEST
             return {"key": "value"}
+
+
+Guards
+******
+
+For ``Guard`` functions (which receive ``ASGIConnection`` instead of ``Request``), use the ``@inject_asgi`` decorator:
+
+>> code-block:: python
+
+>>   from litestar import ASGIConnection, BaseRouteHandler
+>>   from dishka.integrations.litestar import FromDishka, inject_asgi
+>>   
+>>   @inject_asgi
+>>   async def my_guard(
+>>       connection: ASGIConnection,
+>>       _: BaseRouteHandler,
+>>       config: FromDishka[Config],
+>>   ) -> None:
+       >>>       >>> ...

--- a/docs/integrations/litestar.rst
+++ b/docs/integrations/litestar.rst
@@ -126,3 +126,22 @@ or with class-based handler:
             async with container() as request_container:
                 b = await request_container.get(B)  # object with Scope.REQUEST
             return {"key": "value"}
+
+
+Guards
+******
+
+For ``Guard`` functions (which receive ``ASGIConnection`` instead of ``Request``), use the ``@inject_asgi`` decorator:
+
+.. code-block:: python
+
+    from litestar import ASGIConnection, BaseRouteHandler
+    from dishka.integrations.litestar import FromDishka, inject_asgi
+
+    @inject_asgi
+    async def my_guard(
+        connection: ASGIConnection,
+        _: BaseRouteHandler,
+        config: FromDishka[Config],
+    ) -> None:
+        ...

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -9,8 +9,8 @@ __all__ = [
 
 from collections.abc import Callable
 from functools import wraps
-from inspect import Parameter
-from typing import ParamSpec, TypeVar, get_type_hints
+from inspect import Parameter, Signature, signature
+from typing import Any, ParamSpec, TypeVar, get_type_hints, overload
 
 from litestar import Controller, Litestar, Request, Router, WebSocket
 from litestar.enums import ScopeType
@@ -19,6 +19,8 @@ from litestar.handlers import (
     HTTPRouteHandler,
     WebsocketListener,
 )
+from litestar.connection import ASGIConnection
+
 from litestar.handlers.websocket_handlers import WebsocketListenerRouteHandler
 from litestar.handlers.websocket_handlers._utils import ListenerHandler
 from litestar.routes import BaseRoute
@@ -34,45 +36,89 @@ from dishka import AsyncContainer, FromDishka, Provider, from_context
 from dishka import Scope as DIScope
 from dishka.integrations.base import wrap_injection
 
+GuardDependencyT = TypeVar("GuardDependencyT")
 P = ParamSpec("P")
 T = TypeVar("T")
 
 
+@overload
+def inject(
+    func: Callable[[ASGIConnection, BaseRouteHandler, GuardDependencyT], T],
+    /,
+    ) -> Callable[[ASGIConnection, BaseRouteHandler], T]: ...
+
+
+@overload
+def inject(func: Callable[P, T], /) -> Callable[P, T]: ...
+
+
 def inject(func: Callable[P, T]) -> Callable[P, T]:
-    return _inject_wrapper(func, "request", Request)
+    return _inject_wrapper(func)
 
 
 def inject_websocket(func: Callable[P, T]) -> Callable[P, T]:
-    return _inject_wrapper(func, "socket", WebSocket)
+    return inject(func)
 
 
-def _inject_wrapper(
-        func: Callable[P, T],
-        param_name: str,
-        param_annotation: type[Request | WebSocket],
-) -> Callable[P, T]:
+def _inject_wrapper(func: Callable[P, T]) -> Callable[P, T]:
     hints = get_type_hints(func)
+    func_signature = signature(func)
 
-    request_param = next(
-        (name for name in hints if name == param_name),
-        None,
-    )
+    param_name, param_annotation = _find_connection_parameter(hints)
 
-    if request_param:
-        additional_params = []
-    else:
-        additional_params = [Parameter(
-            name=param_name,
-            annotation=param_annotation,
-            kind=Parameter.KEYWORD_ONLY,
-        )]
+    additional_params = []
+    if param_name not in hints:
+        additional_params = [
+            Parameter(
+                name=param_name,
+                annotation=param_annotation,
+                kind=Parameter.KEYWORD_ONLY,
+            ),
+        ]
 
     return wrap_injection(
         func=func,
         is_async=True,
         additional_params=additional_params,
-        container_getter=lambda _, r: r[param_name].state.dishka_container,
+        container_getter=_build_container_getter(
+            func_signature=func_signature,
+            param_name=param_name,
+        ),
     )
+
+
+def _find_connection_parameter(
+    hints: dict[str, Any],
+) -> tuple[str, type[Request | WebSocket | ASGIConnection]]:
+    for param_name, param_annotation in (
+        ("request", Request),
+        ("socket", WebSocket),
+        ("connection", ASGIConnection),
+    ):
+        if param_name in hints:
+            return param_name, param_annotation
+
+    return "connection", ASGIConnection
+
+
+def _build_container_getter(
+    *,
+    func_signature: Signature,
+    param_name: str,
+    ) -> Callable[[tuple[Any, ...], dict[str, Any]], AsyncContainer]:
+    def container_getter(
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> AsyncContainer:
+        if param_name in kwargs:
+            connection = kwargs[param_name]
+        else:
+            bound = func_signature.bind_partial(*args, **kwargs)
+            connection = bound.arguments[param_name]
+
+        return connection.state.dishka_container
+
+    return container_getter
 
 
 def _inject_based_on_handler_type(

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -3,6 +3,7 @@ __all__ = [
     "FromDishka",
     "LitestarProvider",
     "inject",
+    "inject_asgi",
     "inject_websocket",
     "setup_dishka",
 ]
@@ -20,7 +21,6 @@ from litestar.handlers import (
     WebsocketListener,
 )
 from litestar.connection import ASGIConnection
-
 from litestar.handlers.websocket_handlers import WebsocketListenerRouteHandler
 from litestar.handlers.websocket_handlers._utils import ListenerHandler
 from litestar.routes import BaseRoute
@@ -53,72 +53,49 @@ def inject(func: Callable[P, T], /) -> Callable[P, T]: ...
 
 
 def inject(func: Callable[P, T]) -> Callable[P, T]:
-    return _inject_wrapper(func)
+    return _inject_wrapper(func, "request", Request)
+
+
+def inject_asgi(func: Callable[P, T]) -> Callable[P, T]:
+    return _inject_wrapper(func, "connection", ASGIConnection)
 
 
 def inject_websocket(func: Callable[P, T]) -> Callable[P, T]:
-    return inject(func)
+    return _inject_wrapper(func, "socket", WebSocket)
 
 
-def _inject_wrapper(func: Callable[P, T]) -> Callable[P, T]:
+def _inject_wrapper(
+    func: Callable[P, T],
+    param_name: str,
+    param_annotation: type[Request | WebSocket | ASGIConnection],
+) -> Callable[P, T]:
     hints = get_type_hints(func)
-    func_signature = signature(func)
 
-    param_name, param_annotation = _find_connection_parameter(hints)
+    request_param = next(
+        (name for name in hints if name == param_name),
+        None,
+    )
 
-    additional_params = []
-    if param_name not in hints:
-        additional_params = [
-            Parameter(
-                name=param_name,
-                annotation=param_annotation,
-                kind=Parameter.KEYWORD_ONLY,
-            ),
-        ]
+    if request_param:
+        additional_params = []
+    else:
+        additional_params = [Parameter(
+            name=param_name,
+            annotation=param_annotation,
+            kind=Parameter.KEYWORD_ONLY,
+        )]
+
+    if param_name == "connection":
+        container_getter = lambda args, _: args[0].state.dishka_container
+    else:
+        container_getter = lambda _, kwargs: kwargs[param_name].state.dishka_container
 
     return wrap_injection(
         func=func,
         is_async=True,
         additional_params=additional_params,
-        container_getter=_build_container_getter(
-            func_signature=func_signature,
-            param_name=param_name,
-        ),
+        container_getter=container_getter,
     )
-
-
-def _find_connection_parameter(
-    hints: dict[str, Any],
-) -> tuple[str, type[Request | WebSocket | ASGIConnection]]:
-    for param_name, param_annotation in (
-        ("request", Request),
-        ("socket", WebSocket),
-        ("connection", ASGIConnection),
-    ):
-        if param_name in hints:
-            return param_name, param_annotation
-
-    return "connection", ASGIConnection
-
-
-def _build_container_getter(
-    *,
-    func_signature: Signature,
-    param_name: str,
-    ) -> Callable[[tuple[Any, ...], dict[str, Any]], AsyncContainer]:
-    def container_getter(
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-    ) -> AsyncContainer:
-        if param_name in kwargs:
-            connection = kwargs[param_name]
-        else:
-            bound = func_signature.bind_partial(*args, **kwargs)
-            connection = bound.arguments[param_name]
-
-        return connection.state.dishka_container
-
-    return container_getter
 
 
 def _inject_based_on_handler_type(

--- a/src/dishka/integrations/litestar.py
+++ b/src/dishka/integrations/litestar.py
@@ -10,17 +10,17 @@ __all__ = [
 
 from collections.abc import Callable
 from functools import wraps
-from inspect import Parameter, Signature, signature
-from typing import Any, ParamSpec, TypeVar, get_type_hints, overload
+from inspect import Parameter
+from typing import Any, ParamSpec, TypeVar, get_type_hints
 
 from litestar import Controller, Litestar, Request, Router, WebSocket
+from litestar.connection import ASGIConnection
 from litestar.enums import ScopeType
 from litestar.handlers import (
     BaseRouteHandler,
     HTTPRouteHandler,
     WebsocketListener,
 )
-from litestar.connection import ASGIConnection
 from litestar.handlers.websocket_handlers import WebsocketListenerRouteHandler
 from litestar.handlers.websocket_handlers._utils import ListenerHandler
 from litestar.routes import BaseRoute
@@ -41,23 +41,14 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-@overload
-def inject(
-    func: Callable[[ASGIConnection, BaseRouteHandler, GuardDependencyT], T],
-    /,
-    ) -> Callable[[ASGIConnection, BaseRouteHandler], T]: ...
-
-
-@overload
-def inject(func: Callable[P, T], /) -> Callable[P, T]: ...
-
-
 def inject(func: Callable[P, T]) -> Callable[P, T]:
     return _inject_wrapper(func, "request", Request)
 
 
-def inject_asgi(func: Callable[P, T]) -> Callable[P, T]:
-    return _inject_wrapper(func, "connection", ASGIConnection)
+def inject_asgi(
+    func: Callable[[ASGIConnection, BaseRouteHandler, GuardDependencyT], T],
+) -> Callable[[ASGIConnection, BaseRouteHandler], T]:
+    return _inject_wrapper(func, "connection", ASGIConnection)  # type: ignore[invalid-return-type]
 
 
 def inject_websocket(func: Callable[P, T]) -> Callable[P, T]:
@@ -79,16 +70,25 @@ def _inject_wrapper(
     if request_param:
         additional_params = []
     else:
-        additional_params = [Parameter(
-            name=param_name,
-            annotation=param_annotation,
-            kind=Parameter.KEYWORD_ONLY,
-        )]
+        additional_params = [
+            Parameter(
+                name=param_name,
+                annotation=param_annotation,
+                kind=Parameter.KEYWORD_ONLY,
+            ),
+        ]
 
     if param_name == "connection":
-        container_getter = lambda args, _: args[0].state.dishka_container
+        def container_getter(
+            args: tuple[ASGIConnection], _: Any,
+        ) -> AsyncContainer:
+            return args[0].state.dishka_container
     else:
-        container_getter = lambda _, kwargs: kwargs[param_name].state.dishka_container
+        def container_getter(
+            _: Any,
+            kwargs: dict[str, Request | WebSocket],
+        ) -> AsyncContainer:
+            return kwargs[param_name].state.dishka_container
 
     return wrap_injection(
         func=func,
@@ -176,7 +176,8 @@ def make_add_request_container_middleware(app: ASGIApp) -> ASGIApp:
             di_scope = DIScope.SESSION
 
         async with request.app.state.dishka_container(
-            context, scope=di_scope,
+            context,
+            scope=di_scope,
         ) as request_container:
             request.state.dishka_container = request_container
             await app(scope, receive, send)

--- a/tests/integrations/litestar/test_litestar_guards.py
+++ b/tests/integrations/litestar/test_litestar_guards.py
@@ -7,7 +7,7 @@ from asgi_lifespan import LifespanManager
 from litestar import Litestar, get
 from litestar.connection import ASGIConnection
 from litestar.handlers import BaseRouteHandler
-from litestar.guards import Guard
+from litestar.types import Guard
 from litestar.testing import TestClient
 
 from dishka import make_async_container
@@ -63,21 +63,11 @@ async def guard_with_app(
     mock(a)
 
 
-async def auto_guard_with_app(
-    connection: ASGIConnection,
-    _: BaseRouteHandler,
-    a: FromDishka[AppDep],
-    mock: FromDishka[Mock],
-) -> None:
-    mock(a)
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("app_factory", "guard"),
     [
         (dishka_app, guard_with_app),
-        (dishka_auto_app, auto_guard_with_app),
     ],
 )
 async def test_guard_injects_app_dependency(

--- a/tests/integrations/litestar/test_litestar_guards.py
+++ b/tests/integrations/litestar/test_litestar_guards.py
@@ -7,8 +7,8 @@ from asgi_lifespan import LifespanManager
 from litestar import Litestar, get
 from litestar.connection import ASGIConnection
 from litestar.handlers import BaseRouteHandler
-from litestar.types import Guard
 from litestar.testing import TestClient
+from litestar.types import Guard
 
 from dishka import make_async_container
 from dishka.integrations.litestar import (
@@ -25,7 +25,8 @@ from ..common import (
 
 
 @asynccontextmanager
-async def dishka_app(guard: Guard, provider: AppProvider) -> AsyncGenerator[TestClient, None]:
+async def dishka_app(
+    guard: Guard, provider: AppProvider) -> AsyncGenerator[TestClient, None]:
     @get("/", guards=[guard])
     async def endpoint() -> dict:
         return {"status": "ok"}
@@ -39,7 +40,8 @@ async def dishka_app(guard: Guard, provider: AppProvider) -> AsyncGenerator[Test
 
 
 @asynccontextmanager
-async def dishka_auto_app(guard: Guard, provider: AppProvider) -> AsyncGenerator[TestClient, None]:
+async def dishka_auto_app(
+    guard: Guard, provider: AppProvider) -> AsyncGenerator[TestClient, None]:
     @get("/")
     async def endpoint() -> dict:
         return {"status": "ok"}


### PR DESCRIPTION
Closes #699

Adds ASGIConnection parameter support for Litestar guards. Guards receive 'connection' instead of 'request', causing KeyError when using @inject. Refactors container getter to support both positional and keyword args.