### PR TITLE
remove dead code

### DIFF
--- a/src/dishka/dependency_source/factory.py
+++ b/src/dishka/dependency_source/factory.py
@@ -128,23 +128,6 @@ class Factory(FactoryData):
             when_dependencies=self.when_dependencies,
         )
 
-    def with_scope(self, scope: BaseScope) -> Factory:
-        return Factory(
-            dependencies=tuple(self.dependencies),
-            kw_dependencies=dict(self.kw_dependencies),
-            source=self.source,
-            provides=self.provides,
-            scope=self.scope or scope,
-            is_to_bind=self.is_to_bind,
-            cache=self.cache,
-            type_=self.type,
-            allow_static_evaluation=self.allow_static_evaluation,
-            when_override=self.when_override,
-            when_active=self.when_active,
-            when_component=self.when_component,
-            when_dependencies=self.when_dependencies,
-        )
-
     def replace(
         self,
         scope: MayBe[BaseScope] = Special.OMITTED,

--- a/src/dishka/provider/norm_type.py
+++ b/src/dishka/provider/norm_type.py
@@ -16,10 +16,6 @@ from dishka.dependency_source import (
 from dishka.dependency_source.type_replace import replace_type
 
 
-def is_bound_method(obj: Any) -> bool:
-    return ismethod(obj) and bool(obj.__self__)
-
-
 def _get_self_type(source: Any) -> Any:
     if not ismethod(source):
         return None


### PR DESCRIPTION
`with_scope` added in [1.8.0](https://github.com/reagento/dishka/blob/1.8.0/src/dishka/dependency_source/factory.py#L139) but it wasn't used anywhere (It wasn't included in the previous version ([1.7.2](https://github.com/reagento/dishka/blob/1.7.2/src/dishka/dependency_source/factory.py)))



