### PR TITLE
Add Annotated type hint to WithParents for better type checking

### DIFF
--- a/src/dishka/entities/with_parents.py
+++ b/src/dishka/entities/with_parents.py
@@ -156,8 +156,10 @@ class ParentsResolver:
 
 
 if TYPE_CHECKING:  # ast-grep-ignore: DISHKA001
+    from typing import Annotated
+
     T = TypeVar("T")
-    WithParents: TypeAlias = T
+    WithParents: TypeAlias = Annotated[T, "WithParents"]
 else:
     class WithParents:
         def __class_getitem__(cls, item: TypeHint) -> TypeHint:

--- a/tests/type_checking/test_with_parents.py
+++ b/tests/type_checking/test_with_parents.py
@@ -1,0 +1,23 @@
+from dishka import (
+    Provider,
+    Scope,
+    WithParents,
+)
+
+
+class Service:
+    pass
+
+
+class ServiceImpl(Service):
+    pass
+
+
+def get_service() -> WithParents[ServiceImpl]:
+    return ServiceImpl()
+
+
+service: ServiceImpl = get_service()
+
+provider = Provider(scope=Scope.APP)
+provider.provide(get_service, provides=WithParents[ServiceImpl])


### PR DESCRIPTION
 ty cannot checked `dishka.WithParents` correctly

```python
class IFoo: ...

class Foo(IFoo): ...

class Provider(dishka.Provider):
    foo = dishka.provide(dishka.WithParents[Foo])

```

ty check:

```

error[not-subscriptable]: Cannot subscript object of type `TypeVar` with no `__getitem__` method
    |
100 |     foo = dishka.provide(dishka.WithParents[Foo])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^
    |
```

This PR will fix it