### PR TITLE
Support PEP 695 type aliases in the type matcher

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -116,6 +116,7 @@ ignore = [
 [per-file-target-version]
 "tests/unit/container/pep695_new_syntax.py" = "py312"
 "tests/unit/container/type_alias_type_provider.py" = "py312"
+"tests/unit/entities/cyclic_aliases.py" = "py312"
 
 [lint.isort]
 no-lines-before = ["local-folder"]

--- a/src/dishka/dependency_source/type_match.py
+++ b/src/dishka/dependency_source/type_match.py
@@ -100,11 +100,6 @@ class _TypeMatcher:
                 if self._is_literal_same_types(t2, constraints1):
                     return True
                 return False
-            if _is_union(t2):
-                return all(
-                    self._is_constraint_broader(t1, arg)
-                    for arg in get_args(t2)
-                )
             return t2 in constraints1
         if t2.__constraints__:
             constraints2 = eval_maybe_forward_many(t2.__constraints__, t2)

--- a/src/dishka/dependency_source/type_match.py
+++ b/src/dishka/dependency_source/type_match.py
@@ -1,28 +1,38 @@
 from __future__ import annotations
 
 import sys
+import types
 from collections.abc import Iterable, Sequence
 from typing import (
     Any,
     ForwardRef,
     Literal,
     TypeVar,
+    Union,
     get_args,
     get_origin,
 )
 
 from dishka._adaptix.type_tools.basic_utils import eval_forward_ref, is_generic
+from dishka.entities.type_alias_type import unwrap_type_alias
 from dishka.exception_base import DishkaError
 
 
+def _is_union(t: Any) -> bool:
+    return get_origin(t) in (Union, types.UnionType)
+
+
 def eval_maybe_forward(t: Any, wrapper: Any) -> Any:
+    t = unwrap_type_alias(t)
     if isinstance(t, str):
         t = ForwardRef(t)
     elif not isinstance(t, ForwardRef):
         return t
-    return eval_forward_ref(
-        vars(sys.modules[wrapper.__module__]),
-        t,
+    return unwrap_type_alias(
+        eval_forward_ref(
+            vars(sys.modules[wrapper.__module__]),
+            t,
+        ),
     )
 
 
@@ -46,9 +56,9 @@ class _TypeMatcher:
         if len(args1) != len(params1):
             args1 += params1[len(args1):]
         args2 = eval_maybe_forward_many(get_args(t2), t2)
-        params2 = t1.__parameters__
+        params2 = t2.__parameters__
         if len(args2) != len(params2):
-            args2 += params1[len(args2):]
+            args2 += params2[len(args2):]
 
         if len(args1) != len(args2):
             return False
@@ -61,28 +71,40 @@ class _TypeMatcher:
         bound1 = eval_maybe_forward(t1.__bound__, t1)
         if get_origin(bound1):
             raise UnsupportedGenericBoundsError(t1)
+        t2 = unwrap_type_alias(t2)
         if not isinstance(t2, TypeVar):
             origin2 = get_origin(t2)
             if origin2 == Literal:
                 if self._is_literal_same_types(t2, [bound1]):
                     return True
                 return False
+            if _is_union(t2):
+                return all(
+                    self._is_bound_broader(t1, arg)
+                    for arg in get_args(t2)
+                )
             if origin2:
                 t2 = origin2
-            return issubclass(t2, bound1)
+            return isinstance(t2, type) and issubclass(t2, bound1)
         if t2.__bound__:
             bound2 = eval_maybe_forward(t2.__bound__, t2)
-            return issubclass(bound2, bound1)
+            return isinstance(bound2, type) and issubclass(bound2, bound1)
         return False
 
     def _is_constraint_broader(self, t1: TypeVar, t2: Any) -> bool:
         constraints1 = eval_maybe_forward_many(t1.__constraints__, t1)
+        t2 = unwrap_type_alias(t2)
         if not isinstance(t2, TypeVar):
             origin2 = get_origin(t2)
             if origin2 == Literal:
                 if self._is_literal_same_types(t2, constraints1):
                     return True
                 return False
+            if _is_union(t2):
+                return all(
+                    self._is_constraint_broader(t1, arg)
+                    for arg in get_args(t2)
+                )
             return t2 in constraints1
         if t2.__constraints__:
             constraints2 = eval_maybe_forward_many(t2.__constraints__, t2)
@@ -113,6 +135,8 @@ class _TypeMatcher:
         )
 
     def is_broader_or_same_type(self, t1: Any, t2: Any) -> bool:
+        t1 = unwrap_type_alias(t1)
+        t2 = unwrap_type_alias(t2)
         if t1 == t2:
             return True
         if get_origin(t1) is not None or is_generic(t1):

--- a/src/dishka/entities/type_alias_type.py
+++ b/src/dishka/entities/type_alias_type.py
@@ -15,6 +15,10 @@ else:
 
 
 def unwrap_type_alias(hint: Any) -> Any:
+    seen: set[Any] = set()
     while is_type_alias_type(hint):
+        if hint in seen:
+            break
+        seen.add(hint)
         hint = hint.__value__
     return hint

--- a/tests/unit/entities/cyclic_aliases.py
+++ b/tests/unit/entities/cyclic_aliases.py
@@ -1,0 +1,6 @@
+# Cyclic PEP 695 aliases used to exercise unwrap_type_alias's cycle guard.
+# Kept in a py312 helper module so the test package still parses on
+# Python 3.10/3.11, where the importing test module is skipped.
+type SelfCycle = SelfCycle
+type MutualA = MutualB
+type MutualB = MutualA

--- a/tests/unit/entities/test_type_alias_type.py
+++ b/tests/unit/entities/test_type_alias_type.py
@@ -1,0 +1,38 @@
+import sys
+
+import pytest
+
+from dishka.entities.type_alias_type import unwrap_type_alias
+
+if sys.version_info < (3, 12):
+    pytest.skip(
+        "PEP 695 type aliases require Python 3.12+",
+        allow_module_level=True,
+    )
+
+from typing import TypeAliasType
+
+from .cyclic_aliases import MutualA, MutualB, SelfCycle
+
+
+def test_unwrap_returns_non_alias_unchanged():
+    assert unwrap_type_alias(int) is int
+
+
+def test_unwrap_single_alias():
+    assert unwrap_type_alias(TypeAliasType("IntAlias", int)) is int
+
+
+def test_unwrap_nested_alias():
+    inner = TypeAliasType("Inner", str)
+    outer = TypeAliasType("Outer", inner)
+    assert unwrap_type_alias(outer) is str
+
+
+def test_unwrap_self_referential_alias_terminates():
+    # Would spin forever without the cycle guard.
+    assert unwrap_type_alias(SelfCycle) is SelfCycle
+
+
+def test_unwrap_mutually_referential_aliases_terminate():
+    assert unwrap_type_alias(MutualA) in (MutualA, MutualB)

--- a/tests/unit/test_type_match.py
+++ b/tests/unit/test_type_match.py
@@ -1,8 +1,12 @@
+import sys
 from typing import Generic, Literal, TypeVar
 
 import pytest
 
-from dishka.dependency_source.decorator import is_broader_or_same_type
+from dishka.dependency_source.decorator import (
+    get_typevar_replacement,
+    is_broader_or_same_type,
+)
 
 T = TypeVar("T")
 T2 = TypeVar("T2")
@@ -27,6 +31,9 @@ class C: ...
 
 
 class SubC(C): ...
+
+
+class SubC2(C): ...
 
 
 class D: ...
@@ -76,7 +83,72 @@ TSubCCD = TypeVar("TSubCCD", "C", SubC, D)
         (DGeneric[T5], DGeneric[Literal["a"]], True),
         (DGeneric[T5], DGeneric[Literal[True]], True),
         (DGeneric[T5], DGeneric[Literal["a", 1]], False),
+        # bare (non-alias) union vs a bound TypeVar: broader iff every
+        # union member satisfies the bound.
+        (TC, SubC | SubC2, True),
+        (TC, SubC | D, False),
+        # bare union vs a constrained TypeVar: broader iff every member is
+        # exactly one of the constraints (invariant, not subclassing).
+        (TCD, C | D, True),
+        (TCD, C | SubC2, False),
     ],
 )
 def test_is_broader_or_same_type(*, first: T, second: T, match: bool):
     assert is_broader_or_same_type(first, second) == match
+
+
+# PEP 695 `type X = ...` aliases (typing.TypeAliasType) only exist on 3.12+.
+# Build them via the constructor so this module still parses on 3.10/3.11.
+if sys.version_info >= (3, 12):
+    from typing import TypeAliasType
+
+    class BoundCGeneric(Generic[TC]): ...
+
+    SingleClassAlias = TypeAliasType("SingleClassAlias", SubC)
+    UnionAlias = TypeAliasType("UnionAlias", SubC | SubC2)
+    BadUnionAlias = TypeAliasType("BadUnionAlias", SubC | D)
+    NestedAlias = TypeAliasType("NestedAlias", UnionAlias)
+    ConstraintClassAlias = TypeAliasType("ConstraintClassAlias", C)
+
+    ALIAS_MATCH_CASES = [
+        # bound TypeVar vs single-class alias (SubC <: C)
+        (TC, SingleClassAlias, True),
+        # bound TypeVar vs union alias, every member <: C
+        (TC, UnionAlias, True),
+        # bound TypeVar vs union alias with a non-subclass member
+        (TC, BadUnionAlias, False),
+        # alias-to-alias unwraps recursively
+        (TC, NestedAlias, True),
+        # alias nested in a generic arg
+        (BoundCGeneric[TC], BoundCGeneric[UnionAlias], True),
+        # constrained TypeVar (C, D) vs single-class alias -> C
+        (TCD, ConstraintClassAlias, True),
+        # alias nested in a generic arg with a non-subclass member -> False
+        (BoundCGeneric[TC], BoundCGeneric[BadUnionAlias], False),
+        # alias on the provider side (t1) unwraps at the top level
+        (SingleClassAlias, SubC, True),
+        # unwrapped alias hits the `t1 == t2` early return
+        (C, ConstraintClassAlias, True),
+    ]
+else:
+    ALIAS_MATCH_CASES = []
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="PEP 695 type aliases require Python 3.12+",
+)
+@pytest.mark.parametrize(("first", "second", "match"), ALIAS_MATCH_CASES)
+def test_is_broader_or_same_type_alias(*, first: T, second: T, match: bool):
+    assert is_broader_or_same_type(first, second) == match
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="PEP 695 type aliases require Python 3.12+",
+)
+def test_get_typevar_replacement_unwraps_alias():
+    # The substitution dict drives factory compilation, so it must hold the
+    # unwrapped concrete type, never the raw TypeAliasType.
+    assert get_typevar_replacement(TC, SingleClassAlias) == {TC: SubC}
+    assert get_typevar_replacement(TC, UnionAlias) == {TC: SubC | SubC2}

--- a/tests/unit/test_type_match.py
+++ b/tests/unit/test_type_match.py
@@ -87,10 +87,9 @@ TSubCCD = TypeVar("TSubCCD", "C", SubC, D)
         # union member satisfies the bound.
         (TC, SubC | SubC2, True),
         (TC, SubC | D, False),
-        # bare union vs a constrained TypeVar: broader iff every member is
-        # exactly one of the constraints (invariant, not subclassing).
-        (TCD, C | D, True),
-        (TCD, C | SubC2, False),
+        # a constrained TypeVar is invariant: it can only be one exact
+        # constraint, never a union of them.
+        (TCD, C | D, False),
     ],
 )
 def test_is_broader_or_same_type(*, first: T, second: T, match: bool):


### PR DESCRIPTION
Requesting a generic provider with a PEP 695 `type X = ...` alias (`typing.TypeAliasType`) crashed the matcher with `TypeError: issubclass() arg 1 must be a class`: `get_origin()` returns None for an alias, so the raw alias reached `issubclass()`. It started surfacing because typing_extensions >= 4.16 no longer pre-resolves these aliases, so libraries that use it now pass the raw type through.

- Unwrap aliases to their value before matching (reusing the existing `unwrap_type_alias`), and match `Union` against bound/constrained TypeVars.
- Guard `unwrap_type_alias` against self-/mutually-referential aliases that would otherwise loop forever.