### PR TITLE
docs: add dishka-fastmcp community integration

### DIFF
--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -21,6 +21,7 @@ Some of the integrations are supported by a community, refer to their documentat
    celery
    click
    fastapi
+   FastMCP <https://github.com/bagowix/dishka-fastmcp>
    faststream
    flask
    flet <https://github.com/C3EQUALZz/dishka-flet>
@@ -64,7 +65,7 @@ Some of the integrations are supported by a community, refer to their documentat
    * - :ref:`Flask`
      -
      - :ref:`Celery`
-     -
+     - `FastMCP <https://github.com/bagowix/dishka-fastmcp>`_ (:abbr:`com (Community support)`)
    * -  :ref:`Litestar`
      -
      - `RQ <https://github.com/prepin/dishka-rq>`_ (:abbr:`com (Community support)`)


### PR DESCRIPTION
## Summary

Add `dishka-fastmcp` to the official integration index as a community-supported
FastMCP integration.

The implementation remains in its standalone repository and PyPI package, in
line with Dishka's policy for new integrations:

- https://github.com/bagowix/dishka-fastmcp
- https://pypi.org/project/dishka-fastmcp/

## Scope

This PR only adds the external project link to the hidden integration toctree
and the community-support table. It does not add runtime code or dependencies to
Dishka.

This follows the existing documentation pattern used for other external
community integrations.

## Package checks

- Python 3.11-3.14 CI matrix
- Minimum versions: Dishka 1.10.1 and FastMCP 3.2.4
- Ruff, mypy, and Pyright
- 100% test coverage