### PR TITLE
docs(contributing): require pip>=25.1 for dependency groups

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -17,14 +17,13 @@ Getting started
 
 .. code-block::
 
-    python3 -m venv .venv
+    python3 -m venv --upgrade-deps .venv
     source .venv/bin/activate
 
 3. Install development tools and project itself:
 
 .. code-block::
 
-    pip install --upgrade pip  # --group requires pip>=25.1
     pip install --group dev
     uv pip install -e .
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -24,6 +24,7 @@ Getting started
 
 .. code-block::
 
+    pip install --upgrade pip  # --group requires pip>=25.1
     pip install --group dev
     uv pip install -e .
 


### PR DESCRIPTION
## Problem

The third setup step in `docs/contributing.rst` fails on a new virtualenv:

```console
$ python3 -m venv .venv
$ source .venv/bin/activate
$ pip install --group dev

Usage:
  pip install [options] <requirement specifier> [package-index-options] ...
  ...
no such option: --group

$ python3 --version
Python 3.12.3
$ pip --version
pip 24.0 from /home/***/dishka/.venv/lib/python3.12/site-packages/pip (python 3.12)
```

Creating the virtualenv with `--upgrade-deps` makes it work:

```console
$ python3 -m venv --upgrade-deps .venv
$ pip --version
pip 26.2 from /home/***/dishka/.venv/lib/python3.12/site-packages/pip (python 3.12)

$ pip install --group dev
...
Successfully installed ... mypy-2.1.0 nox-2026.4.10 ruff-0.15.15 uv-0.11.19 ...
```

## Why

The `--group` option was added in pip 25.1 (2025-04-26):
https://pip.pypa.io/en/stable/news/#v25-1

> Add a `--group` option which allows installation from PEP 735 Dependency Groups.

The `--upgrade-deps` flag upgrades pip when the virtualenv is created: https://docs.python.org/3/library/venv.html

>  --upgrade-deps: Upgrade core dependencies (pip) to the latest version in PyPI.

A newly created virtualenv may have an older pip, so the very first setup
command fails for new contributors as it did in my case.
